### PR TITLE
feat: add `jsondiffpatch`

### DIFF
--- a/README.bun.md
+++ b/README.bun.md
@@ -8,35 +8,36 @@ for Node please refer to [Node](README.md)
 
 cpu: 13th Gen Intel(R) Core(TM) i5-13400F
 
-runtime: bun 1.2.21 (x64-win32)
+runtime: bun 1.2.23 (x64-win32)
 
 ### json
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| @ungap/structured-clone | 28,978 | 2,857 |
-| clone | 32,096 | 379 |
-| clone-deep | 165,814 | 864 |
-| clone(circular) | 28,645 | 3,362 |
-| copy-anything | 45,240 | 468 |
-| core-js/structured-clone | 12,090 | 1,529 |
-| deepcopy | 12,416 | 1,255 |
-| es-toolkit.cloneDeep | 55,631 | 5,183 |
-| fast-copy | 169,743 | 12,254 |
-| fastest-json-copy | 295,523 | 1,540 |
-| JSON.stringify/parse | 41,296 | 773 |
-| just-clone | 21,425 | 376 |
-| klona | 69,270 | 1,107 |
-| klona/json | 72,015 | 1,224 |
-| klona/lite | 67,176 | 1,139 |
-| lodash.cloneDeep | 20,963 | 1,899 |
-| nano-copy | 59,219 | 5,183 |
-| nanoclone | 73,173 | 8,768 |
-| plain-object-clone | 28,738 | 458 |
-| ramda.clone | 9,077 | 629 |
-| rfdc | 36,170 | 622 |
-| rfdc(circles) | 35,866 | 587 |
-| structuredClone | 28,976 | 2,966 |
+| @ungap/structured-clone | 27,925 | 2,700 |
+| clone | 30,606 | 297 |
+| clone-deep | 160,164 | 786 |
+| clone(circular) | 27,283 | 1,813 |
+| copy-anything | 41,794 | 398 |
+| core-js/structured-clone | 11,803 | 1,556 |
+| deepcopy | 11,966 | 1,007 |
+| es-toolkit.cloneDeep | 52,606 | 2,735 |
+| fast-copy | 159,041 | 3,729 |
+| fastest-json-copy | 290,261 | 1,352 |
+| JSON.stringify/parse | 40,229 | 726 |
+| jsondiffpatch.clone | 66,671 | 1,132 |
+| just-clone | 20,320 | 346 |
+| klona | 61,188 | 1,022 |
+| klona/json | 68,426 | 1,143 |
+| klona/lite | 64,102 | 1,035 |
+| lodash.cloneDeep | 19,394 | 1,878 |
+| nano-copy | 51,124 | 4,770 |
+| nanoclone | 73,945 | 8,145 |
+| plain-object-clone | 27,589 | 459 |
+| ramda.clone | 8,345 | 606 |
+| rfdc | 34,078 | 574 |
+| rfdc(circles) | 33,514 | 588 |
+| structuredClone | 27,945 | 2,834 |
 
 ![json small](assets/bun/json-small.svg)
 ![json large](assets/bun/json-large.svg)
@@ -45,18 +46,18 @@ runtime: bun 1.2.21 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| @ungap/structured-clone | 381,515 | 570 |
-| clone(circular) | 846,355 | 263 |
-| core-js/structured-clone | 324,764 | 243 |
-| deepcopy | 391,700 | 270 |
-| es-toolkit.cloneDeep | 1,541,208 | 1,059 |
-| fast-copy | 3,334,660 | 2,797 |
-| lodash.cloneDeep | 907,826 | 565 |
-| nano-copy | 2,761,832 | 2,656 |
-| nanoclone | 2,940,552 | 1,868 |
-| ramda.clone | 267,324 | 54 |
-| rfdc(circles) | 3,053,795 | 1,102 |
-| structuredClone | 366,558 | 574 |
+| @ungap/structured-clone | 356,688 | 594 |
+| clone(circular) | 444,667 | 232 |
+| core-js/structured-clone | 328,409 | 229 |
+| deepcopy | 299,121 | 251 |
+| es-toolkit.cloneDeep | 750,628 | 1,058 |
+| fast-copy | 954,822 | 2,637 |
+| lodash.cloneDeep | 522,205 | 521 |
+| nano-copy | 1,086,204 | 2,300 |
+| nanoclone | 2,028,367 | 1,804 |
+| ramda.clone | 245,506 | 55 |
+| rfdc(circles) | 1,143,905 | 1,018 |
+| structuredClone | 358,709 | 573 |
 
 ![json-circular small](assets/bun/json-circular-small.svg)
 ![json-circular large](assets/bun/json-circular-large.svg)
@@ -65,23 +66,24 @@ runtime: bun 1.2.21 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| @ungap/structured-clone | 61,411 | 9,213 |
-| clone | 47,831 | 705 |
-| clone-deep | 46,096 | 595 |
-| clone(circular) | 44,471 | 4,228 |
-| core-js/structured-clone | 29,203 | 3,157 |
-| deepcopy | 20,870 | 2,241 |
-| es-toolkit.cloneDeep | 54,066 | 5,474 |
-| fast-copy | 54,584 | 6,049 |
-| just-clone | 76,458 | 1,145 |
-| klona | 77,089 | 1,024 |
-| klona/lite | 76,272 | 1,135 |
-| lodash.cloneDeep | 25,997 | 2,137 |
-| nano-copy | 160,396 | 15,372 |
-| nanoclone | 230,728 | 19,197 |
-| ramda.clone | 27,269 | 2,489 |
-| rfdc(with RegExp) | 68,177 | 1,012 |
-| structuredClone | 59,224 | 9,346 |
+| @ungap/structured-clone | 56,979 | 8,855 |
+| clone | 44,856 | 659 |
+| clone-deep | 43,654 | 562 |
+| clone(circular) | 41,857 | 4,143 |
+| core-js/structured-clone | 29,552 | 3,106 |
+| deepcopy | 20,847 | 2,126 |
+| es-toolkit.cloneDeep | 51,213 | 5,336 |
+| fast-copy | 53,138 | 5,607 |
+| jsondiffpatch.clone | 46,705 | 679 |
+| just-clone | 78,186 | 1,120 |
+| klona | 70,424 | 1,062 |
+| klona/lite | 69,138 | 1,038 |
+| lodash.cloneDeep | 23,698 | 2,098 |
+| nano-copy | 159,422 | 14,037 |
+| nanoclone | 235,302 | 19,066 |
+| ramda.clone | 26,403 | 2,401 |
+| rfdc(with RegExp) | 64,891 | 969 |
+| structuredClone | 56,566 | 8,825 |
 
 ![regexp small](assets/bun/regexp-small.svg)
 ![regexp large](assets/bun/regexp-large.svg)
@@ -90,24 +92,25 @@ runtime: bun 1.2.21 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| @ungap/structured-clone | 45,239 | 15,528 |
-| clone | 32,363 | 569 |
-| clone-deep | 51,327 | 941 |
-| clone(circular) | 29,816 | 5,191 |
-| core-js/structured-clone | 13,923 | 2,299 |
-| deepcopy | 14,193 | 3,088 |
-| es-toolkit.cloneDeep | 38,784 | 14,512 |
-| fast-copy | 46,183 | 12,710 |
-| just-clone | 45,218 | 835 |
-| klona | 65,162 | 1,281 |
-| klona/lite | 66,123 | 1,229 |
-| lodash.cloneDeep | 22,662 | 4,161 |
-| nano-copy | 60,838 | 19,705 |
-| nanoclone | 86,673 | 23,141 |
-| ramda.clone | 16,827 | 3,448 |
-| rfdc | 72,544 | 1,317 |
-| rfdc(circles) | 74,042 | 1,308 |
-| structuredClone | 45,700 | 15,713 |
+| @ungap/structured-clone | 44,777 | 14,540 |
+| clone | 32,334 | 574 |
+| clone-deep | 50,722 | 957 |
+| clone(circular) | 28,607 | 4,757 |
+| core-js/structured-clone | 13,095 | 2,221 |
+| deepcopy | 13,425 | 3,001 |
+| es-toolkit.cloneDeep | 38,938 | 12,956 |
+| fast-copy | 43,137 | 12,376 |
+| jsondiffpatch.clone | 87,232 | 1,630 |
+| just-clone | 44,567 | 805 |
+| klona | 64,070 | 1,161 |
+| klona/lite | 64,126 | 1,222 |
+| lodash.cloneDeep | 20,847 | 3,835 |
+| nano-copy | 63,882 | 18,284 |
+| nanoclone | 83,057 | 22,349 |
+| ramda.clone | 16,555 | 3,217 |
+| rfdc | 74,765 | 1,308 |
+| rfdc(circles) | 70,322 | 1,255 |
+| structuredClone | 44,712 | 14,920 |
 
 ![date small](assets/bun/date-small.svg)
 ![date large](assets/bun/date-large.svg)
@@ -116,16 +119,16 @@ runtime: bun 1.2.21 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| clone | 372,886 | 1,116 |
-| clone(circular) | 333,922 | 806 |
-| es-toolkit.cloneDeep | 496,764 | 1,324 |
-| fast-copy | 490,660 | 1,691 |
-| klona | 743,160 | 2,476 |
-| klona/lite | 779,958 | 2,377 |
-| lodash.cloneDeep | 353,721 | 999 |
-| nano-copy | 791,666 | 2,601 |
-| ramda.clone | 203,510 | 337 |
-| rfdc(with Custom Classes) | 1,367,559 | 3,696 |
+| clone | 339,619 | 1,109 |
+| clone(circular) | 320,594 | 740 |
+| es-toolkit.cloneDeep | 460,517 | 1,367 |
+| fast-copy | 479,562 | 1,603 |
+| klona | 745,712 | 2,364 |
+| klona/lite | 729,195 | 2,448 |
+| lodash.cloneDeep | 363,366 | 985 |
+| nano-copy | 773,762 | 2,538 |
+| ramda.clone | 192,200 | 351 |
+| rfdc(with Custom Classes) | 1,385,533 | 3,551 |
 
 ![custom-class small](assets/bun/custom-class-small.svg)
 ![custom-class large](assets/bun/custom-class-large.svg)
@@ -134,14 +137,14 @@ runtime: bun 1.2.21 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| @ungap/structured-clone | 18,437 | 7 |
-| core-js/structured-clone | 30,060 | 29 |
-| es-toolkit.cloneDeep | 30,247 | 20 |
-| fast-copy | 29,044 | 29 |
-| klona | 28,342 | 29 |
-| nano-copy | 31,002 | 30 |
-| rfdc(with ArrayBuffer) | 28,201 | 29 |
-| structuredClone | 18,724 | 7 |
+| @ungap/structured-clone | 18,599 | 7 |
+| core-js/structured-clone | 29,338 | 31 |
+| es-toolkit.cloneDeep | 26,530 | 21 |
+| fast-copy | 27,143 | 31 |
+| klona | 26,719 | 32 |
+| nano-copy | 29,736 | 32 |
+| rfdc(with ArrayBuffer) | 26,149 | 32 |
+| structuredClone | 18,544 | 7 |
 
 ![array-buffer small](assets/bun/array-buffer-small.svg)
 ![array-buffer large](assets/bun/array-buffer-large.svg)
@@ -150,13 +153,13 @@ runtime: bun 1.2.21 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| clone | 121,544 | 33 |
-| clone(circular) | 119,821 | 33 |
-| deepcopy | 44,386 | 16 |
-| klona | 126,630 | 34 |
-| nano-copy | 121,550 | 32 |
-| rfdc | 123,939 | 32 |
-| rfdc(circles) | 131,830 | 34 |
+| clone | 116,304 | 34 |
+| clone(circular) | 118,508 | 34 |
+| deepcopy | 41,580 | 17 |
+| klona | 120,668 | 34 |
+| nano-copy | 120,565 | 34 |
+| rfdc | 126,995 | 34 |
+| rfdc(circles) | 125,427 | 35 |
 
 ![buffer small](assets/bun/buffer-small.svg)
 ![buffer large](assets/bun/buffer-large.svg)
@@ -165,8 +168,8 @@ runtime: bun 1.2.21 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| es-toolkit.cloneDeep | 707,892 | 641,950 |
-| lodash.cloneDeep | 478,717 | 531,045 |
+| es-toolkit.cloneDeep | 672,519 | 632,343 |
+| lodash.cloneDeep | 489,329 | 497,296 |
 
 ![buffer-zero-copy small](assets/bun/buffer-zero-copy-small.svg)
 ![buffer-zero-copy large](assets/bun/buffer-zero-copy-large.svg)
@@ -175,21 +178,21 @@ runtime: bun 1.2.21 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| @ungap/structured-clone | 63,390 | 7,100 |
-| clone | 206,610 | 28,272 |
-| clone(circular) | 156,873 | 20,972 |
-| core-js/structured-clone | 35,610 | 3,120 |
-| deepcopy | 39,233 | 4,094 |
-| es-toolkit.cloneDeep | 82,229 | 13,988 |
-| fast-copy | 203,767 | 28,863 |
-| just-clone | 68,827 | 6,970 |
-| klona | 150,214 | 20,295 |
-| lodash.cloneDeep | 67,767 | 5,373 |
-| nano-copy | 52,091 | 8,167 |
-| nanoclone | 91,022 | 16,111 |
-| rfdc | 55,181 | 5,176 |
-| rfdc(circles) | 56,751 | 5,371 |
-| structuredClone | 65,532 | 7,276 |
+| @ungap/structured-clone | 63,019 | 6,782 |
+| clone | 200,257 | 18,125 |
+| clone(circular) | 146,690 | 20,118 |
+| core-js/structured-clone | 27,421 | 3,073 |
+| deepcopy | 38,562 | 3,662 |
+| es-toolkit.cloneDeep | 81,090 | 13,049 |
+| fast-copy | 174,376 | 16,306 |
+| just-clone | 66,448 | 5,874 |
+| klona | 145,510 | 19,484 |
+| lodash.cloneDeep | 67,031 | 4,841 |
+| nano-copy | 50,874 | 8,441 |
+| nanoclone | 84,173 | 9,983 |
+| rfdc | 55,198 | 4,907 |
+| rfdc(circles) | 55,327 | 4,892 |
+| structuredClone | 64,660 | 7,162 |
 
 ![map-set small](assets/bun/map-set-small.svg)
 ![map-set large](assets/bun/map-set-large.svg)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is a benchmark for JS deep clone libraries.
 | fast-copy | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
 | fastest-json-copy | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | JSON.stringify/parse | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| jsondiffpatch.clone | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | just-clone | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
 | klona | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | klona/json | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
@@ -42,29 +43,30 @@ runtime: node 24.8.0 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| @ungap/structured-clone | 41,132 | 4,730 |
-| clone | 20,314 | 354 |
-| clone-deep | 96,850 | 1,731 |
-| clone(circular) | 18,017 | 1,937 |
-| copy-anything | 32,113 | 511 |
-| core-js/structured-clone | 15,301 | 1,840 |
-| deepcopy | 18,781 | 2,143 |
-| es-toolkit.cloneDeep | 52,623 | 5,195 |
-| fast-copy | 106,290 | 10,415 |
-| fastest-json-copy | 219,735 | 4,022 |
-| JSON.stringify/parse | 78,689 | 1,391 |
-| just-clone | 24,655 | 424 |
-| klona | 271,176 | 4,602 |
-| klona/json | 319,770 | 5,566 |
-| klona/lite | 294,095 | 4,944 |
-| lodash.cloneDeep | 32,130 | 3,377 |
-| nano-copy | 102,511 | 10,804 |
-| nanoclone | 145,374 | 14,324 |
-| plain-object-clone | 51,821 | 933 |
-| ramda.clone | 9,714 | 676 |
-| rfdc | 168,016 | 2,825 |
-| rfdc(circles) | 139,002 | 2,398 |
-| structuredClone | 40,268 | 4,519 |
+| @ungap/structured-clone | 40,666 | 4,603 |
+| clone | 20,561 | 344 |
+| clone-deep | 93,042 | 1,698 |
+| clone(circular) | 17,622 | 1,868 |
+| copy-anything | 29,734 | 503 |
+| core-js/structured-clone | 15,556 | 1,857 |
+| deepcopy | 18,565 | 2,031 |
+| es-toolkit.cloneDeep | 52,959 | 5,253 |
+| fast-copy | 99,862 | 9,718 |
+| fastest-json-copy | 223,203 | 3,802 |
+| JSON.stringify/parse | 71,548 | 1,322 |
+| jsondiffpatch.clone | 305,298 | 5,314 |
+| just-clone | 24,359 | 415 |
+| klona | 247,348 | 4,276 |
+| klona/json | 311,466 | 5,401 |
+| klona/lite | 279,231 | 4,744 |
+| lodash.cloneDeep | 30,553 | 3,253 |
+| nano-copy | 103,740 | 10,698 |
+| nanoclone | 134,697 | 14,045 |
+| plain-object-clone | 53,516 | 949 |
+| ramda.clone | 9,735 | 576 |
+| rfdc | 151,328 | 2,704 |
+| rfdc(circles) | 140,351 | 2,413 |
+| structuredClone | 40,546 | 4,469 |
 
 ![json small](assets/node/json-small.svg)
 ![json large](assets/node/json-large.svg)
@@ -73,18 +75,18 @@ runtime: node 24.8.0 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| @ungap/structured-clone | 549,175 | 754 |
-| clone(circular) | 368,451 | 198 |
-| core-js/structured-clone | 308,384 | 291 |
-| deepcopy | 598,160 | 350 |
-| es-toolkit.cloneDeep | 1,502,377 | 1,062 |
-| fast-copy | 2,689,444 | 1,494 |
-| lodash.cloneDeep | 977,580 | 617 |
-| nano-copy | 2,598,807 | 1,875 |
-| nanoclone | 3,993,324 | 2,393 |
-| ramda.clone | 275,654 | 68 |
-| rfdc(circles) | 3,805,678 | 2,649 |
-| structuredClone | 538,098 | 745 |
+| @ungap/structured-clone | 516,688 | 747 |
+| clone(circular) | 366,152 | 184 |
+| core-js/structured-clone | 332,227 | 274 |
+| deepcopy | 608,239 | 342 |
+| es-toolkit.cloneDeep | 1,438,584 | 1,051 |
+| fast-copy | 2,560,951 | 1,552 |
+| lodash.cloneDeep | 925,953 | 608 |
+| nano-copy | 2,727,370 | 1,808 |
+| nanoclone | 3,737,974 | 2,356 |
+| ramda.clone | 271,897 | 63 |
+| rfdc(circles) | 3,809,646 | 2,475 |
+| structuredClone | 536,569 | 733 |
 
 ![json-circular small](assets/node/json-circular-small.svg)
 ![json-circular large](assets/node/json-circular-large.svg)
@@ -93,23 +95,24 @@ runtime: node 24.8.0 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| @ungap/structured-clone | 97,430 | 10,984 |
-| clone | 56,840 | 836 |
-| clone-deep | 138,867 | 2,152 |
-| clone(circular) | 48,465 | 4,675 |
-| core-js/structured-clone | 52,287 | 6,345 |
-| deepcopy | 60,637 | 6,646 |
-| es-toolkit.cloneDeep | 151,068 | 15,429 |
-| fast-copy | 162,295 | 17,617 |
-| just-clone | 108,672 | 2,934 |
-| klona | 396,748 | 5,805 |
-| klona/lite | 425,050 | 6,379 |
-| lodash.cloneDeep | 41,525 | 3,633 |
-| nano-copy | 181,194 | 18,734 |
-| nanoclone | 241,709 | 23,623 |
-| ramda.clone | 41,904 | 4,264 |
-| rfdc(with RegExp) | 336,323 | 4,759 |
-| structuredClone | 97,697 | 11,160 |
+| @ungap/structured-clone | 95,531 | 11,189 |
+| clone | 54,366 | 804 |
+| clone-deep | 139,025 | 2,015 |
+| clone(circular) | 47,357 | 4,562 |
+| core-js/structured-clone | 51,706 | 5,973 |
+| deepcopy | 59,582 | 6,509 |
+| es-toolkit.cloneDeep | 144,224 | 15,344 |
+| fast-copy | 163,577 | 16,999 |
+| jsondiffpatch.clone | 106,954 | 1,567 |
+| just-clone | 100,953 | 2,941 |
+| klona | 388,899 | 5,849 |
+| klona/lite | 412,612 | 5,862 |
+| lodash.cloneDeep | 40,024 | 3,519 |
+| nano-copy | 180,148 | 18,776 |
+| nanoclone | 235,787 | 23,036 |
+| ramda.clone | 40,498 | 4,082 |
+| rfdc(with RegExp) | 320,525 | 4,877 |
+| structuredClone | 94,155 | 10,721 |
 
 ![regexp small](assets/node/regexp-small.svg)
 ![regexp large](assets/node/regexp-large.svg)
@@ -118,24 +121,25 @@ runtime: node 24.8.0 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| @ungap/structured-clone | 51,022 | 15,027 |
-| clone | 25,527 | 477 |
-| clone-deep | 75,161 | 1,312 |
-| clone(circular) | 21,676 | 3,299 |
-| core-js/structured-clone | 14,223 | 2,123 |
-| deepcopy | 28,733 | 6,651 |
-| es-toolkit.cloneDeep | 71,033 | 19,878 |
-| fast-copy | 74,718 | 15,651 |
-| just-clone | 131,054 | 2,286 |
-| klona | 160,769 | 2,888 |
-| klona/lite | 154,530 | 2,897 |
-| lodash.cloneDeep | 31,022 | 4,669 |
-| nano-copy | 99,474 | 19,541 |
-| nanoclone | 145,257 | 26,772 |
-| ramda.clone | 18,755 | 3,216 |
-| rfdc | 213,199 | 3,994 |
-| rfdc(circles) | 209,984 | 3,570 |
-| structuredClone | 52,012 | 15,181 |
+| @ungap/structured-clone | 49,639 | 14,494 |
+| clone | 25,406 | 452 |
+| clone-deep | 69,580 | 1,287 |
+| clone(circular) | 21,115 | 3,280 |
+| core-js/structured-clone | 14,042 | 2,075 |
+| deepcopy | 28,680 | 6,336 |
+| es-toolkit.cloneDeep | 67,043 | 19,633 |
+| fast-copy | 73,992 | 15,470 |
+| jsondiffpatch.clone | 301,563 | 5,876 |
+| just-clone | 133,203 | 2,275 |
+| klona | 150,264 | 2,747 |
+| klona/lite | 157,328 | 2,848 |
+| lodash.cloneDeep | 30,124 | 4,615 |
+| nano-copy | 105,022 | 19,181 |
+| nanoclone | 144,683 | 27,277 |
+| ramda.clone | 18,136 | 3,103 |
+| rfdc | 223,439 | 3,971 |
+| rfdc(circles) | 206,164 | 3,556 |
+| structuredClone | 50,673 | 14,579 |
 
 ![date small](assets/node/date-small.svg)
 ![date large](assets/node/date-large.svg)
@@ -144,16 +148,16 @@ runtime: node 24.8.0 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| clone | 377,679 | 1,132 |
-| clone(circular) | 327,267 | 760 |
-| es-toolkit.cloneDeep | 995,611 | 2,860 |
-| fast-copy | 1,114,714 | 3,456 |
-| klona | 2,003,158 | 6,890 |
-| klona/lite | 2,125,210 | 7,140 |
-| lodash.cloneDeep | 643,019 | 1,657 |
-| nano-copy | 1,524,649 | 5,013 |
-| ramda.clone | 232,138 | 383 |
-| rfdc(with Custom Classes) | 3,805,270 | 11,142 |
+| clone | 361,675 | 1,099 |
+| clone(circular) | 314,893 | 709 |
+| es-toolkit.cloneDeep | 1,015,604 | 2,838 |
+| fast-copy | 961,700 | 3,074 |
+| klona | 1,933,790 | 6,335 |
+| klona/lite | 2,087,899 | 6,987 |
+| lodash.cloneDeep | 623,976 | 1,622 |
+| nano-copy | 1,543,168 | 4,916 |
+| ramda.clone | 221,296 | 373 |
+| rfdc(with Custom Classes) | 3,718,964 | 10,963 |
 
 ![custom-class small](assets/node/custom-class-small.svg)
 ![custom-class large](assets/node/custom-class-large.svg)
@@ -162,14 +166,14 @@ runtime: node 24.8.0 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| @ungap/structured-clone | 40,330 | 14 |
-| core-js/structured-clone | 33,011 | 47 |
-| es-toolkit.cloneDeep | 30,863 | 27 |
-| fast-copy | 42,816 | 49 |
-| klona | 46,863 | 49 |
-| nano-copy | 50,244 | 49 |
-| rfdc(with ArrayBuffer) | 53,271 | 49 |
-| structuredClone | 41,130 | 14 |
+| @ungap/structured-clone | 40,395 | 14 |
+| core-js/structured-clone | 33,734 | 47 |
+| es-toolkit.cloneDeep | 28,571 | 26 |
+| fast-copy | 39,575 | 48 |
+| klona | 46,740 | 48 |
+| nano-copy | 48,131 | 49 |
+| rfdc(with ArrayBuffer) | 50,325 | 49 |
+| structuredClone | 40,460 | 14 |
 
 ![array-buffer small](assets/node/array-buffer-small.svg)
 ![array-buffer large](assets/node/array-buffer-large.svg)
@@ -178,13 +182,13 @@ runtime: node 24.8.0 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| clone | 46,318 | 51 |
-| clone(circular) | 49,859 | 53 |
-| deepcopy | 31,726 | 28 |
-| klona | 49,702 | 53 |
-| nano-copy | 64,115 | 53 |
-| rfdc | 65,455 | 53 |
-| rfdc(circles) | 66,018 | 53 |
+| clone | 50,820 | 52 |
+| clone(circular) | 48,384 | 52 |
+| deepcopy | 32,173 | 27 |
+| klona | 55,299 | 52 |
+| nano-copy | 64,509 | 52 |
+| rfdc | 63,749 | 52 |
+| rfdc(circles) | 67,155 | 52 |
 
 ![buffer small](assets/node/buffer-small.svg)
 ![buffer large](assets/node/buffer-large.svg)
@@ -193,8 +197,8 @@ runtime: node 24.8.0 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| es-toolkit.cloneDeep | 945,646 | 971,910 |
-| lodash.cloneDeep | 377,029 | 371,219 |
+| es-toolkit.cloneDeep | 914,192 | 921,485 |
+| lodash.cloneDeep | 383,552 | 371,446 |
 
 ![buffer-zero-copy small](assets/node/buffer-zero-copy-small.svg)
 ![buffer-zero-copy large](assets/node/buffer-zero-copy-large.svg)
@@ -203,21 +207,21 @@ runtime: node 24.8.0 (x64-win32)
 
 | Library | small (ops/s) | large (ops/s) |
 | -- | --: | --: |
-| @ungap/structured-clone | 119,293 | 12,936 |
-| clone | 100,592 | 9,806 |
-| clone(circular) | 90,184 | 7,808 |
-| core-js/structured-clone | 40,675 | 4,163 |
-| deepcopy | 89,621 | 8,988 |
-| es-toolkit.cloneDeep | 272,872 | 25,459 |
-| fast-copy | 274,001 | 24,477 |
-| just-clone | 224,608 | 25,131 |
-| klona | 417,467 | 38,018 |
-| lodash.cloneDeep | 73,427 | 5,716 |
-| nano-copy | 150,495 | 15,140 |
-| nanoclone | 425,143 | 37,400 |
-| rfdc | 153,789 | 20,733 |
-| rfdc(circles) | 152,258 | 20,159 |
-| structuredClone | 123,084 | 13,556 |
+| @ungap/structured-clone | 118,652 | 12,688 |
+| clone | 102,009 | 9,695 |
+| clone(circular) | 84,067 | 7,756 |
+| core-js/structured-clone | 38,108 | 4,090 |
+| deepcopy | 85,371 | 8,363 |
+| es-toolkit.cloneDeep | 274,966 | 24,602 |
+| fast-copy | 263,696 | 24,058 |
+| just-clone | 222,739 | 24,275 |
+| klona | 408,790 | 37,674 |
+| lodash.cloneDeep | 66,928 | 5,653 |
+| nano-copy | 158,587 | 14,805 |
+| nanoclone | 414,181 | 36,774 |
+| rfdc | 153,617 | 19,880 |
+| rfdc(circles) | 154,431 | 19,371 |
+| structuredClone | 117,270 | 12,565 |
 
 ![map-set small](assets/node/map-set-small.svg)
 ![map-set large](assets/node/map-set-large.svg)

--- a/assets/bun/array-buffer-large.svg
+++ b/assets/bun/array-buffer-large.svg
@@ -1,36 +1,38 @@
 <svg width="900" height="376" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 376">
 <rect width="900" height="376" x="0" y="0" fill="#ffffff"></rect>
 <path d="M156.5 65L156.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
-<path d="M265.5 65L265.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
-<path d="M374.5 65L374.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
-<path d="M483.5 65L483.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
-<path d="M592.5 65L592.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
-<path d="M701.5 65L701.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
+<path d="M249.5 65L249.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
+<path d="M343.5 65L343.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
+<path d="M436.5 65L436.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
+<path d="M529.5 65L529.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
+<path d="M623.5 65L623.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
+<path d="M716.5 65L716.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
 <path d="M810.5 65L810.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
 <path d="M156.5 296L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr11-cls-22"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 281.5625)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 252.6875)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 223.8125)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 194.9375)" fill="#111">    rfdc(with ArrayBuffer)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 281.5625)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 252.6875)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 223.8125)" fill="#111">    rfdc(with ArrayBuffer)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 194.9375)" fill="#111">    fast-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 166.0625)" fill="#111">    core-js/structured-clone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 137.1875)" fill="#111">    es-toolkit.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 108.3125)" fill="#111">    structuredClone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.4375)" fill="#111">    @ungap/structured-clone</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 304)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(264.9333 304)" fill="#111">5</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(373.9467 304)" fill="#111">10</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(482.96 304)" fill="#111">15</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(591.9733 304)" fill="#111">20</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(700.9867 304)" fill="#111">25</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 304)" fill="#111">30</text>
-<path d="M155.9 271.6l654.1 0l0 19.9l-654.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
-<path d="M155.9 242.7l632.3 0l0 19.9l-632.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
-<path d="M155.9 213.9l632.3 0l0 19.9l-632.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
-<path d="M155.9 185l632.3 0l0 19.9l-632.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
-<path d="M155.9 156.1l632.3 0l0 19.9l-632.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
-<path d="M155.9 127.2l436.1 0l0 19.9l-436.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
-<path d="M155.9 98.4l152.6 0l0 19.9l-152.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
-<path d="M155.9 69.5l152.6 0l0 19.9l-152.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(249.36 304)" fill="#111">5</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(342.8 304)" fill="#111">10</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(436.24 304)" fill="#111">15</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(529.68 304)" fill="#111">20</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(623.12 304)" fill="#111">25</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(716.56 304)" fill="#111">30</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 304)" fill="#111">35</text>
+<path d="M155.9 271.6l598 0l0 19.9l-598 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
+<path d="M155.9 242.7l598 0l0 19.9l-598 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
+<path d="M155.9 213.9l598 0l0 19.9l-598 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
+<path d="M155.9 185l579.3 0l0 19.9l-579.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
+<path d="M155.9 156.1l579.3 0l0 19.9l-579.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
+<path d="M155.9 127.2l392.4 0l0 19.9l-392.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
+<path d="M155.9 98.4l130.8 0l0 19.9l-130.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
+<path d="M155.9 69.5l130.8 0l0 19.9l-130.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
 <path d="M-115.8 -5l231.6 0l0 28l-231.6 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr11-cls-22"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">array-buffer • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/array-buffer-small.svg
+++ b/assets/bun/array-buffer-small.svg
@@ -1,38 +1,36 @@
 <svg width="900" height="376" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 376">
 <rect width="900" height="376" x="0" y="0" fill="#ffffff"></rect>
 <path d="M156.5 65L156.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr10-cls-20"></path>
-<path d="M249.5 65L249.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr10-cls-20"></path>
-<path d="M343.5 65L343.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr10-cls-20"></path>
-<path d="M436.5 65L436.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr10-cls-20"></path>
-<path d="M529.5 65L529.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr10-cls-20"></path>
-<path d="M623.5 65L623.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr10-cls-20"></path>
-<path d="M716.5 65L716.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr10-cls-20"></path>
+<path d="M265.5 65L265.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr10-cls-20"></path>
+<path d="M374.5 65L374.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr10-cls-20"></path>
+<path d="M483.5 65L483.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr10-cls-20"></path>
+<path d="M592.5 65L592.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr10-cls-20"></path>
+<path d="M701.5 65L701.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr10-cls-20"></path>
 <path d="M810.5 65L810.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr10-cls-20"></path>
 <path d="M156.5 296L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr10-cls-20"></path>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 281.5625)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 252.6875)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 223.8125)" fill="#111">    core-js/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 194.9375)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 166.0625)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 252.6875)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 223.8125)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 194.9375)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 166.0625)" fill="#111">    es-toolkit.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 137.1875)" fill="#111">    rfdc(with ArrayBuffer)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 108.3125)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.4375)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 108.3125)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.4375)" fill="#111">    structuredClone</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 304)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(249.36 304)" fill="#111">5.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(342.8 304)" fill="#111">10.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(436.24 304)" fill="#111">15.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(529.68 304)" fill="#111">20.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(623.12 304)" fill="#111">25.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(716.56 304)" fill="#111">30.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 304)" fill="#111">35.0k</text>
-<path d="M155.9 271.6l579.4 0l0 19.9l-579.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 242.7l565.3 0l0 19.9l-565.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 213.9l561.8 0l0 19.9l-561.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 185l542.8 0l0 19.9l-542.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 156.1l529.7 0l0 19.9l-529.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 127.2l527 0l0 19.9l-527 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 98.4l349.9 0l0 19.9l-349.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 69.5l344.6 0l0 19.9l-344.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(264.9333 304)" fill="#111">5.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(373.9467 304)" fill="#111">10.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(482.96 304)" fill="#111">15.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(591.9733 304)" fill="#111">20.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(700.9867 304)" fill="#111">25.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 304)" fill="#111">30.0k</text>
+<path d="M155.9 271.6l648.3 0l0 19.9l-648.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 242.7l639.6 0l0 19.9l-639.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 213.9l591.8 0l0 19.9l-591.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 185l582.5 0l0 19.9l-582.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 156.1l578.4 0l0 19.9l-578.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 127.2l570.1 0l0 19.9l-570.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 98.4l405.5 0l0 19.9l-405.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 69.5l404.3 0l0 19.9l-404.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
 <path d="M-116.7 -5l233.4 0l0 28l-233.4 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr10-cls-20"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">array-buffer • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/buffer-large.svg
+++ b/assets/bun/buffer-large.svg
@@ -1,36 +1,30 @@
 <svg width="900" height="348" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 348">
 <rect width="900" height="348" x="0" y="0" fill="#ffffff"></rect>
 <path d="M135.5 65L135.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr13-cls-26"></path>
-<path d="M231.5 65L231.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr13-cls-26"></path>
-<path d="M328.5 65L328.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr13-cls-26"></path>
-<path d="M424.5 65L424.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr13-cls-26"></path>
-<path d="M520.5 65L520.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr13-cls-26"></path>
-<path d="M617.5 65L617.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr13-cls-26"></path>
-<path d="M713.5 65L713.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr13-cls-26"></path>
+<path d="M304.5 65L304.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr13-cls-26"></path>
+<path d="M472.5 65L472.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr13-cls-26"></path>
+<path d="M641.5 65L641.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr13-cls-26"></path>
 <path d="M810.5 65L810.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr13-cls-26"></path>
 <path d="M135.5 268L135.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr13-cls-26"></path>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 253.5)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 224.5)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 195.5)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 166.5)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 137.5)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 224.5)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 195.5)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 166.5)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 137.5)" fill="#111">    klona</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 108.5)" fill="#111">    nano-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 79.5)" fill="#111">    deepcopy</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(135 276)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(231.4286 276)" fill="#111">5</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(327.8571 276)" fill="#111">10</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(424.2857 276)" fill="#111">15</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(520.7143 276)" fill="#111">20</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(617.1429 276)" fill="#111">25</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(713.5714 276)" fill="#111">30</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 276)" fill="#111">35</text>
-<path d="M135 243.5l655.7 0l0 20l-655.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
-<path d="M135 214.5l655.7 0l0 20l-655.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
-<path d="M135 185.5l636.4 0l0 20l-636.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
-<path d="M135 156.5l636.4 0l0 20l-636.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
-<path d="M135 127.5l617.1 0l0 20l-617.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
-<path d="M135 98.5l617.1 0l0 20l-617.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
-<path d="M135 69.5l308.6 0l0 20l-308.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(303.75 276)" fill="#111">10</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(472.5 276)" fill="#111">20</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(641.25 276)" fill="#111">30</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 276)" fill="#111">40</text>
+<path d="M135 243.5l590.6 0l0 20l-590.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<path d="M135 214.5l573.8 0l0 20l-573.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<path d="M135 185.5l573.8 0l0 20l-573.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<path d="M135 156.5l573.8 0l0 20l-573.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<path d="M135 127.5l573.8 0l0 20l-573.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<path d="M135 98.5l573.8 0l0 20l-573.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<path d="M135 69.5l286.9 0l0 20l-286.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
 <path d="M-92.3 -5l184.6 0l0 28l-184.6 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr13-cls-26"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">buffer • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/buffer-small.svg
+++ b/assets/bun/buffer-small.svg
@@ -7,12 +7,12 @@
 <path d="M675.5 65L675.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr12-cls-24"></path>
 <path d="M810.5 65L810.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr12-cls-24"></path>
 <path d="M135.5 268L135.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr12-cls-24"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 253.5)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 224.5)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 195.5)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 253.5)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 224.5)" fill="#111">    rfdc(circles)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 195.5)" fill="#111">    klona</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 166.5)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 137.5)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 108.5)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 137.5)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 108.5)" fill="#111">    clone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 79.5)" fill="#111">    deepcopy</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(135 276)" fill="#111">0</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(270 276)" fill="#111">30.0k</text>
@@ -20,13 +20,13 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(540 276)" fill="#111">90.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(675 276)" fill="#111">120.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 276)" fill="#111">150.0k</text>
-<path d="M135 243.5l593.2 0l0 20l-593.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
-<path d="M135 214.5l569.8 0l0 20l-569.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
-<path d="M135 185.5l557.7 0l0 20l-557.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
-<path d="M135 156.5l547 0l0 20l-547 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
-<path d="M135 127.5l546.9 0l0 20l-546.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
-<path d="M135 98.5l539.2 0l0 20l-539.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
-<path d="M135 69.5l199.7 0l0 20l-199.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 243.5l571.5 0l0 20l-571.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 214.5l564.4 0l0 20l-564.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 185.5l543 0l0 20l-543 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 156.5l542.5 0l0 20l-542.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 127.5l533.3 0l0 20l-533.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 98.5l523.4 0l0 20l-523.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 69.5l187.1 0l0 20l-187.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
 <path d="M-93.2 -5l186.4 0l0 28l-186.4 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr12-cls-24"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">buffer • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/buffer-zero-copy-large.svg
+++ b/assets/bun/buffer-zero-copy-large.svg
@@ -19,8 +19,8 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(617.1429 136)" fill="#111">500.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(713.5714 136)" fill="#111">600.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 136)" fill="#111">700.0k</text>
-<path d="M135 101.4l619 0l0 21.7l-619 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr15-cls-31"></path>
-<path d="M135 69.9l512.1 0l0 21.7l-512.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr15-cls-31"></path>
+<path d="M135 101.4l609.8 0l0 21.7l-609.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr15-cls-31"></path>
+<path d="M135 69.9l479.5 0l0 21.7l-479.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr15-cls-31"></path>
 <path d="M-134.9 -5l269.7 0l0 28l-269.7 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr15-cls-30"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">buffer-zero-copy • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/buffer-zero-copy-small.svg
+++ b/assets/bun/buffer-zero-copy-small.svg
@@ -1,28 +1,26 @@
 <svg width="900" height="208" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 208">
 <rect width="900" height="208" x="0" y="0" fill="#ffffff"></rect>
 <path d="M135.5 65L135.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
-<path d="M219.5 65L219.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
-<path d="M304.5 65L304.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
-<path d="M388.5 65L388.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
-<path d="M472.5 65L472.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
-<path d="M557.5 65L557.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
-<path d="M641.5 65L641.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
-<path d="M725.5 65L725.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
+<path d="M231.5 65L231.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
+<path d="M328.5 65L328.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
+<path d="M424.5 65L424.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
+<path d="M520.5 65L520.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
+<path d="M617.5 65L617.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
+<path d="M713.5 65L713.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
 <path d="M810.5 65L810.5 128" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr14-cls-28"></path>
 <path d="M135.5 128L135.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr14-cls-28"></path>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 112.25)" fill="#111">    es-toolkit.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 80.75)" fill="#111">    lodash.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(135 136)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(219.375 136)" fill="#111">100.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(303.75 136)" fill="#111">200.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(388.125 136)" fill="#111">300.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(472.5 136)" fill="#111">400.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(556.875 136)" fill="#111">500.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(641.25 136)" fill="#111">600.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(725.625 136)" fill="#111">700.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 136)" fill="#111">800.0k</text>
-<path d="M135 101.4l597.3 0l0 21.7l-597.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr14-cls-29"></path>
-<path d="M135 69.9l403.9 0l0 21.7l-403.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr14-cls-29"></path>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(231.4286 136)" fill="#111">100.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(327.8571 136)" fill="#111">200.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(424.2857 136)" fill="#111">300.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(520.7143 136)" fill="#111">400.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(617.1429 136)" fill="#111">500.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(713.5714 136)" fill="#111">600.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 136)" fill="#111">700.0k</text>
+<path d="M135 101.4l648.5 0l0 21.7l-648.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr14-cls-29"></path>
+<path d="M135 69.9l471.9 0l0 21.7l-471.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr14-cls-29"></path>
 <path d="M-135.8 -5l271.5 0l0 28l-271.5 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr14-cls-28"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">buffer-zero-copy • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/custom-class-large.svg
+++ b/assets/bun/custom-class-large.svg
@@ -8,8 +8,8 @@
 <path d="M160.5 352L160.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr9-cls-18"></path>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 337.65)" fill="#111">    rfdc(with Custom Classes)</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 308.95)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 280.25)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 251.55)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 280.25)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 251.55)" fill="#111">    klona</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 222.85)" fill="#111">    fast-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 194.15)" fill="#111">    es-toolkit.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 165.45)" fill="#111">    clone</text>
@@ -21,16 +21,16 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(485.3 360)" fill="#111">2.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(647.65 360)" fill="#111">3.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 360)" fill="#111">4.0k</text>
-<path d="M160.6 327.7l600 0l0 19.8l-600 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 299l422.3 0l0 19.8l-422.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 270.3l402 0l0 19.8l-402 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 241.6l385.9 0l0 19.8l-385.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 212.9l274.5 0l0 19.8l-274.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 184.2l215 0l0 19.8l-215 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 155.5l181.2 0l0 19.8l-181.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 126.8l162.2 0l0 19.8l-162.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 98.1l130.9 0l0 19.8l-130.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 69.4l54.7 0l0 19.8l-54.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 327.7l576.5 0l0 19.8l-576.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 299l412 0l0 19.8l-412 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 270.3l397.4 0l0 19.8l-397.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 241.6l383.8 0l0 19.8l-383.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 212.9l260.2 0l0 19.8l-260.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 184.2l221.9 0l0 19.8l-221.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 155.5l180 0l0 19.8l-180 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 126.8l159.9 0l0 19.8l-159.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 98.1l120.1 0l0 19.8l-120.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 69.4l57 0l0 19.8l-57 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
 <path d="M-121.7 -5l243.5 0l0 28l-243.5 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr9-cls-18"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">custom-class • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/custom-class-small.svg
+++ b/assets/bun/custom-class-small.svg
@@ -9,12 +9,12 @@
 <path d="M160.5 352L160.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr8-cls-16"></path>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 337.65)" fill="#111">    rfdc(with Custom Classes)</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 308.95)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 280.25)" fill="#111">    klona/lite</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 251.55)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 222.85)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 194.15)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 165.45)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 136.75)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 280.25)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 251.55)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 222.85)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 194.15)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 165.45)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 136.75)" fill="#111">    clone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 108.05)" fill="#111">    clone(circular)</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 79.35)" fill="#111">    ramda.clone</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(160.6 360)" fill="#111">0</text>
@@ -23,16 +23,16 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(550.24 360)" fill="#111">900.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(680.12 360)" fill="#111">1.2M</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 360)" fill="#111">1.5M</text>
-<path d="M160.6 327.7l592.1 0l0 19.8l-592.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 299l342.7 0l0 19.8l-342.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 270.3l337.7 0l0 19.8l-337.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 241.6l321.7 0l0 19.8l-321.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 212.9l215.1 0l0 19.8l-215.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 184.2l212.4 0l0 19.8l-212.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 155.5l161.4 0l0 19.8l-161.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 126.8l153.1 0l0 19.8l-153.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 98.1l144.6 0l0 19.8l-144.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 69.4l88.1 0l0 19.8l-88.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 327.7l599.8 0l0 19.8l-599.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 299l335 0l0 19.8l-335 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 270.3l322.8 0l0 19.8l-322.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 241.6l315.7 0l0 19.8l-315.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 212.9l207.6 0l0 19.8l-207.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 184.2l199.4 0l0 19.8l-199.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 155.5l157.3 0l0 19.8l-157.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 126.8l147 0l0 19.8l-147 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 98.1l138.8 0l0 19.8l-138.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 69.4l83.2 0l0 19.8l-83.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
 <path d="M-122.6 -5l245.3 0l0 28l-245.3 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr8-cls-16"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">custom-class • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/date-large.svg
+++ b/assets/bun/date-large.svg
@@ -1,54 +1,56 @@
-<svg width="900" height="656" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 656">
-<rect width="900" height="656" x="0" y="0" fill="#ffffff"></rect>
-<path d="M156.5 65L156.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
-<path d="M286.5 65L286.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
-<path d="M417.5 65L417.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
-<path d="M548.5 65L548.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
-<path d="M679.5 65L679.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
-<path d="M810.5 65L810.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
-<path d="M156.5 576L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr7-cls-14"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 561.8056)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.4167)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 505.0278)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.6389)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 448.25)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 419.8611)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.4722)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.0833)" fill="#111">    lodash.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.6944)" fill="#111">    ramda.clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.3056)" fill="#111">    deepcopy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.9167)" fill="#111">    core-js/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.5278)" fill="#111">    rfdc</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.1389)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.75)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.3611)" fill="#111">    klona/lite</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.9722)" fill="#111">    clone-deep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.5833)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1944)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 584)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 584)" fill="#111">5.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 584)" fill="#111">10.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 584)" fill="#111">15.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 584)" fill="#111">20.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 584)" fill="#111">25.0k</text>
-<path d="M155.9 552l605.4 0l0 19.6l-605.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 523.6l515.5 0l0 19.6l-515.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 495.2l411.1 0l0 19.6l-411.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 466.8l406.3 0l0 19.6l-406.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 438.5l379.7 0l0 19.6l-379.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 410.1l332.5 0l0 19.6l-332.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 381.7l135.8 0l0 19.6l-135.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 353.3l108.9 0l0 19.6l-108.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 324.9l90.2 0l0 19.6l-90.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 296.5l80.8 0l0 19.6l-80.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 268.1l60.1 0l0 19.6l-60.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 239.7l34.5 0l0 19.6l-34.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 211.3l34.2 0l0 19.6l-34.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 183l33.5 0l0 19.6l-33.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 154.6l32.2 0l0 19.6l-32.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 126.2l24.6 0l0 19.6l-24.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 97.8l21.8 0l0 19.6l-21.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 69.4l14.9 0l0 19.6l-14.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<svg width="900" height="684" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 684">
+<rect width="900" height="684" x="0" y="0" fill="#ffffff"></rect>
+<path d="M156.5 65L156.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
+<path d="M286.5 65L286.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
+<path d="M417.5 65L417.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
+<path d="M548.5 65L548.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
+<path d="M679.5 65L679.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
+<path d="M810.5 65L810.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
+<path d="M156.5 604L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr7-cls-14"></path>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 589.8158)" fill="#111">    nanoclone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 561.4474)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.0789)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 504.7105)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.3421)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 447.9737)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 419.6053)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.2368)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 362.8684)" fill="#111">    ramda.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.5)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.1316)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.7632)" fill="#111">    jsondiffpatch.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.3947)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.0263)" fill="#111">    rfdc(circles)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.6579)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.2895)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.9211)" fill="#111">    clone-deep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.5526)" fill="#111">    just-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1842)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 612)" fill="#111">0</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 612)" fill="#111">5.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 612)" fill="#111">10.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 612)" fill="#111">15.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 612)" fill="#111">20.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 612)" fill="#111">25.0k</text>
+<path d="M155.9 580l584.7 0l0 19.6l-584.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 551.7l478.4 0l0 19.6l-478.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 523.3l390.4 0l0 19.6l-390.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 494.9l380.4 0l0 19.6l-380.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 466.6l339 0l0 19.6l-339 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 438.2l323.8 0l0 19.6l-323.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 409.8l124.5 0l0 19.6l-124.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 381.4l100.3 0l0 19.6l-100.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 353.1l84.2 0l0 19.6l-84.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 324.7l78.5 0l0 19.6l-78.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 296.3l58.1 0l0 19.6l-58.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 268l42.6 0l0 19.6l-42.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 239.6l34.2 0l0 19.6l-34.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 211.2l32.8 0l0 19.6l-32.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 182.9l32 0l0 19.6l-32 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 154.5l30.4 0l0 19.6l-30.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 126.1l25 0l0 19.6l-25 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 97.8l21.1 0l0 19.6l-21.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 69.4l15 0l0 19.6l-15 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="18" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
 <path d="M-86.8 -5l173.6 0l0 28l-173.6 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr7-cls-14"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">date • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/date-small.svg
+++ b/assets/bun/date-small.svg
@@ -1,54 +1,56 @@
-<svg width="900" height="656" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 656">
-<rect width="900" height="656" x="0" y="0" fill="#ffffff"></rect>
-<path d="M156.5 65L156.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
-<path d="M286.5 65L286.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
-<path d="M417.5 65L417.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
-<path d="M548.5 65L548.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
-<path d="M679.5 65L679.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
-<path d="M810.5 65L810.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
-<path d="M156.5 576L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr6-cls-12"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 561.8056)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.4167)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 505.0278)" fill="#111">    rfdc</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.6389)" fill="#111">    klona/lite</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 448.25)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 419.8611)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.4722)" fill="#111">    clone-deep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.0833)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.6944)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.3056)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.9167)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.5278)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.1389)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.75)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.3611)" fill="#111">    lodash.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.9722)" fill="#111">    ramda.clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.5833)" fill="#111">    deepcopy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1944)" fill="#111">    core-js/structured-clone</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 584)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 584)" fill="#111">20.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 584)" fill="#111">40.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 584)" fill="#111">60.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 584)" fill="#111">80.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 584)" fill="#111">100.0k</text>
-<path d="M155.9 552l566.9 0l0 19.6l-566.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 523.6l484.3 0l0 19.6l-484.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 495.2l474.5 0l0 19.6l-474.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 466.8l432.5 0l0 19.6l-432.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 438.5l426.2 0l0 19.6l-426.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 410.1l397.9 0l0 19.6l-397.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 381.7l335.7 0l0 19.6l-335.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 353.3l302.1 0l0 19.6l-302.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 324.9l298.9 0l0 19.6l-298.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 296.5l295.9 0l0 19.6l-295.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 268.1l295.8 0l0 19.6l-295.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 239.7l253.7 0l0 19.6l-253.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 211.3l211.7 0l0 19.6l-211.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 183l195 0l0 19.6l-195 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 154.6l148.2 0l0 19.6l-148.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 126.2l110.1 0l0 19.6l-110.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 97.8l92.8 0l0 19.6l-92.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 69.4l91.1 0l0 19.6l-91.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<svg width="900" height="684" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 684">
+<rect width="900" height="684" x="0" y="0" fill="#ffffff"></rect>
+<path d="M156.5 65L156.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M286.5 65L286.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M417.5 65L417.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M548.5 65L548.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M679.5 65L679.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M810.5 65L810.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M156.5 604L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr6-cls-12"></path>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 589.8158)" fill="#111">    jsondiffpatch.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 561.4474)" fill="#111">    nanoclone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.0789)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 504.7105)" fill="#111">    rfdc(circles)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.3421)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 447.9737)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 419.6053)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.2368)" fill="#111">    clone-deep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 362.8684)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.5)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.1316)" fill="#111">    just-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.7632)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.3947)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.0263)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.6579)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.2895)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.9211)" fill="#111">    ramda.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.5526)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1842)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 612)" fill="#111">0</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 612)" fill="#111">20.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 612)" fill="#111">40.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 612)" fill="#111">60.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 612)" fill="#111">80.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 612)" fill="#111">100.0k</text>
+<path d="M155.9 580l570.6 0l0 19.6l-570.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 551.7l543.3 0l0 19.6l-543.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 523.3l489 0l0 19.6l-489 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 494.9l460 0l0 19.6l-460 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 466.6l419.4 0l0 19.6l-419.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 438.2l419.1 0l0 19.6l-419.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 409.8l417.8 0l0 19.6l-417.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 381.4l331.8 0l0 19.6l-331.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 353.1l292.9 0l0 19.6l-292.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 324.7l292.5 0l0 19.6l-292.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 296.3l291.5 0l0 19.6l-291.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 268l282.2 0l0 19.6l-282.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 239.6l254.7 0l0 19.6l-254.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 211.2l211.5 0l0 19.6l-211.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 182.9l187.1 0l0 19.6l-187.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 154.5l136.4 0l0 19.6l-136.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 126.1l108.3 0l0 19.6l-108.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 97.8l87.8 0l0 19.6l-87.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 69.4l85.7 0l0 19.6l-85.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="18" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
 <path d="M-87.7 -5l175.4 0l0 28l-175.4 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr6-cls-12"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">date • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/json-circular-large.svg
+++ b/assets/bun/json-circular-large.svg
@@ -11,10 +11,10 @@
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 393.7083)" fill="#111">    fast-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 365.125)" fill="#111">    nano-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 336.5417)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 307.9583)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 279.375)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 250.7917)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 222.2083)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 307.9583)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 279.375)" fill="#111">    rfdc(circles)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 250.7917)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 222.2083)" fill="#111">    structuredClone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 193.625)" fill="#111">    lodash.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 165.0417)" fill="#111">    deepcopy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 136.4583)" fill="#111">    clone(circular)</text>
@@ -27,18 +27,18 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(591.9733 416)" fill="#111">2.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(700.9867 416)" fill="#111">2.5k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 416)" fill="#111">3.0k</text>
-<path d="M155.9 383.8l609.8 0l0 19.7l-609.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 355.3l579.1 0l0 19.7l-579.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 326.7l407.3 0l0 19.7l-407.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 298.1l240.3 0l0 19.7l-240.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 269.5l230.9 0l0 19.7l-230.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 240.9l125.1 0l0 19.7l-125.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 212.3l124.3 0l0 19.7l-124.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 183.8l123.2 0l0 19.7l-123.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 155.2l58.9 0l0 19.7l-58.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 126.6l57.3 0l0 19.7l-57.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 98l53 0l0 19.7l-53 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 69.4l11.8 0l0 19.7l-11.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 383.8l574.9 0l0 19.7l-574.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 355.3l501.5 0l0 19.7l-501.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 326.7l393.3 0l0 19.7l-393.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 298.1l230.7 0l0 19.7l-230.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 269.5l222 0l0 19.7l-222 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 240.9l129.5 0l0 19.7l-129.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 212.3l124.9 0l0 19.7l-124.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 183.8l113.6 0l0 19.7l-113.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 155.2l54.7 0l0 19.7l-54.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 126.6l50.6 0l0 19.7l-50.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 98l49.9 0l0 19.7l-49.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 69.4l12 0l0 19.7l-12 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
 <path d="M-117.7 -5l235.4 0l0 28l-235.4 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr3-cls-6"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">json-circular • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/json-circular-small.svg
+++ b/assets/bun/json-circular-small.svg
@@ -1,46 +1,42 @@
 <svg width="900" height="488" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 488">
 <rect width="900" height="488" x="0" y="0" fill="#ffffff"></rect>
 <path d="M156.5 65L156.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
-<path d="M249.5 65L249.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
-<path d="M343.5 65L343.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
-<path d="M436.5 65L436.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
-<path d="M529.5 65L529.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
-<path d="M623.5 65L623.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
-<path d="M716.5 65L716.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
+<path d="M286.5 65L286.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
+<path d="M417.5 65L417.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
+<path d="M548.5 65L548.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
+<path d="M679.5 65L679.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
 <path d="M810.5 65L810.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
 <path d="M156.5 408L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr2-cls-4"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 393.7083)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 393.7083)" fill="#111">    nanoclone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 365.125)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 336.5417)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 307.9583)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 336.5417)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 307.9583)" fill="#111">    fast-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 279.375)" fill="#111">    es-toolkit.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 250.7917)" fill="#111">    lodash.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 222.2083)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 193.625)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 193.625)" fill="#111">    structuredClone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 165.0417)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 136.4583)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.875)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 136.4583)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.875)" fill="#111">    deepcopy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.2917)" fill="#111">    ramda.clone</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 416)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(249.36 416)" fill="#111">500.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(342.8 416)" fill="#111">1.0M</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(436.24 416)" fill="#111">1.5M</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(529.68 416)" fill="#111">2.0M</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(623.12 416)" fill="#111">2.5M</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(716.56 416)" fill="#111">3.0M</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 416)" fill="#111">3.5M</text>
-<path d="M155.9 383.8l623.2 0l0 19.7l-623.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 355.3l570.7 0l0 19.7l-570.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 326.7l549.5 0l0 19.7l-549.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 298.1l516.1 0l0 19.7l-516.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 269.5l288 0l0 19.7l-288 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 240.9l169.7 0l0 19.7l-169.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 212.3l158.2 0l0 19.7l-158.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 183.8l73.2 0l0 19.7l-73.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 155.2l71.3 0l0 19.7l-71.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 126.6l68.5 0l0 19.7l-68.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 98l60.7 0l0 19.7l-60.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 69.4l50 0l0 19.7l-50 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 416)" fill="#111">500.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 416)" fill="#111">1.0M</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 416)" fill="#111">1.5M</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 416)" fill="#111">2.0M</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 416)" fill="#111">2.5M</text>
+<path d="M155.9 383.8l530.7 0l0 19.7l-530.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 355.3l299.3 0l0 19.7l-299.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 326.7l284.2 0l0 19.7l-284.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 298.1l249.8 0l0 19.7l-249.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 269.5l196.4 0l0 19.7l-196.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 240.9l136.6 0l0 19.7l-136.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 212.3l116.3 0l0 19.7l-116.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 183.8l93.8 0l0 19.7l-93.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 155.2l93.3 0l0 19.7l-93.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 126.6l85.9 0l0 19.7l-85.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 98l78.3 0l0 19.7l-78.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 69.4l64.2 0l0 19.7l-64.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
 <path d="M-118.6 -5l237.2 0l0 28l-237.2 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr2-cls-4"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">json-circular • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/json-large.svg
+++ b/assets/bun/json-large.svg
@@ -1,68 +1,66 @@
-<svg width="900" height="796" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 796">
-<rect width="900" height="796" x="0" y="0" fill="#ffffff"></rect>
-<path d="M156.5 65L156.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M249.5 65L249.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M343.5 65L343.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M436.5 65L436.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M529.5 65L529.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M623.5 65L623.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M716.5 65L716.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M810.5 65L810.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M156.5 716L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr1-cls-2"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 701.8478)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 673.5435)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 645.2391)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 616.9348)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 588.6304)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 560.3261)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 532.0217)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 503.7174)" fill="#111">    lodash.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 475.413)" fill="#111">    fastest-json-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 447.1087)" fill="#111">    core-js/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 418.8043)" fill="#111">    deepcopy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 390.5)" fill="#111">    klona/json</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 362.1957)" fill="#111">    klona/lite</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 333.8913)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 305.587)" fill="#111">    clone-deep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.2826)" fill="#111">    JSON.stringify/parse</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 248.9783)" fill="#111">    ramda.clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 220.6739)" fill="#111">    rfdc</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.3696)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.0652)" fill="#111">    copy-anything</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.7609)" fill="#111">    plain-object-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.4565)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1522)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 724)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(249.36 724)" fill="#111">2.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(342.8 724)" fill="#111">4.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(436.24 724)" fill="#111">6.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(529.68 724)" fill="#111">8.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(623.12 724)" fill="#111">10.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(716.56 724)" fill="#111">12.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 724)" fill="#111">14.0k</text>
-<path d="M155.9 692.1l572.5 0l0 19.5l-572.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 663.8l409.6 0l0 19.5l-409.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 635.5l242.1 0l0 19.5l-242.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 607.2l242.1 0l0 19.5l-242.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 578.9l157.1 0l0 19.5l-157.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 550.6l138.6 0l0 19.5l-138.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 522.3l133.5 0l0 19.5l-133.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 494l88.7 0l0 19.5l-88.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 465.6l71.9 0l0 19.5l-71.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 437.3l71.4 0l0 19.5l-71.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 409l58.6 0l0 19.5l-58.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 380.7l57.2 0l0 19.5l-57.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 352.4l53.2 0l0 19.5l-53.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 324.1l51.7 0l0 19.5l-51.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 295.8l40.4 0l0 19.5l-40.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 267.5l36.1 0l0 19.5l-36.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 239.2l29.4 0l0 19.5l-29.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 210.9l29.1 0l0 19.5l-29.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 182.6l27.4 0l0 19.5l-27.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="18" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 154.3l21.9 0l0 19.5l-21.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="19" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 126l21.4 0l0 19.5l-21.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="20" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 97.7l17.7 0l0 19.5l-17.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="21" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 69.4l17.6 0l0 19.5l-17.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="22" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<svg width="900" height="824" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 824">
+<rect width="900" height="824" x="0" y="0" fill="#ffffff"></rect>
+<path d="M156.5 65L156.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
+<path d="M286.5 65L286.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
+<path d="M417.5 65L417.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
+<path d="M548.5 65L548.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
+<path d="M679.5 65L679.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
+<path d="M810.5 65L810.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
+<path d="M156.5 744L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr1-cls-2"></path>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 729.8542)" fill="#111">    nanoclone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 701.5625)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 673.2708)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 644.9792)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 616.6875)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 588.3958)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 560.1042)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 531.8125)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 503.5208)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 475.2292)" fill="#111">    fastest-json-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 446.9375)" fill="#111">    klona/json</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 418.6458)" fill="#111">    jsondiffpatch.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 390.3542)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 362.0625)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 333.7708)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 305.4792)" fill="#111">    clone-deep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.1875)" fill="#111">    JSON.stringify/parse</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 248.8958)" fill="#111">    ramda.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 220.6042)" fill="#111">    rfdc(circles)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.3125)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.0208)" fill="#111">    plain-object-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.7292)" fill="#111">    copy-anything</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.4375)" fill="#111">    just-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1458)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 752)" fill="#111">0</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 752)" fill="#111">2.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 752)" fill="#111">4.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 752)" fill="#111">6.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 752)" fill="#111">8.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 752)" fill="#111">10.0k</text>
+<path d="M155.9 720.1l532.7 0l0 19.5l-532.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 691.8l312 0l0 19.5l-312 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 663.5l243.9 0l0 19.5l-243.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 635.2l185.4 0l0 19.5l-185.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 606.9l178.9 0l0 19.5l-178.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 578.6l176.6 0l0 19.5l-176.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 550.3l122.8 0l0 19.5l-122.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 522.1l118.6 0l0 19.5l-118.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 493.8l101.8 0l0 19.5l-101.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 465.5l88.4 0l0 19.5l-88.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 437.2l74.8 0l0 19.5l-74.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 408.9l74 0l0 19.5l-74 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 380.6l67.7 0l0 19.5l-67.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 352.3l66.8 0l0 19.5l-66.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 324l65.9 0l0 19.5l-65.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 295.7l51.4 0l0 19.5l-51.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 267.4l47.5 0l0 19.5l-47.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 239.1l39.6 0l0 19.5l-39.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 210.8l38.5 0l0 19.5l-38.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="18" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 182.6l37.5 0l0 19.5l-37.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="19" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 154.3l30 0l0 19.5l-30 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="20" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 126l26 0l0 19.5l-26 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="21" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 97.7l22.6 0l0 19.5l-22.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="22" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 69.4l19.4 0l0 19.5l-19.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="23" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
 <path d="M-85.7 -5l171.5 0l0 28l-171.5 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr1-cls-2"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">json • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/json-small.svg
+++ b/assets/bun/json-small.svg
@@ -1,66 +1,68 @@
-<svg width="900" height="796" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 796">
-<rect width="900" height="796" x="0" y="0" fill="#ffffff"></rect>
-<path d="M156.5 65L156.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M265.5 65L265.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M374.5 65L374.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M483.5 65L483.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M592.5 65L592.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M701.5 65L701.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M810.5 65L810.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M156.5 716L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr0-cls-0"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 701.8478)" fill="#111">    fastest-json-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 673.5435)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 645.2391)" fill="#111">    clone-deep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 616.9348)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 588.6304)" fill="#111">    klona/json</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 560.3261)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 532.0217)" fill="#111">    klona/lite</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 503.7174)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 475.413)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 447.1087)" fill="#111">    copy-anything</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 418.8043)" fill="#111">    JSON.stringify/parse</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 390.5)" fill="#111">    rfdc</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 362.1957)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 333.8913)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 305.587)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.2826)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 248.9783)" fill="#111">    plain-object-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 220.6739)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.3696)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.0652)" fill="#111">    lodash.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.7609)" fill="#111">    deepcopy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.4565)" fill="#111">    core-js/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1522)" fill="#111">    ramda.clone</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 724)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(264.9333 724)" fill="#111">50.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(373.9467 724)" fill="#111">100.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(482.96 724)" fill="#111">150.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(591.9733 724)" fill="#111">200.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(700.9867 724)" fill="#111">250.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 724)" fill="#111">300.0k</text>
-<path d="M155.9 692.1l644.3 0l0 19.5l-644.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 663.8l370.1 0l0 19.5l-370.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 635.5l361.5 0l0 19.5l-361.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 607.2l159.5 0l0 19.5l-159.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 578.9l157 0l0 19.5l-157 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 550.6l151 0l0 19.5l-151 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 522.3l146.5 0l0 19.5l-146.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 494l129.1 0l0 19.5l-129.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 465.6l121.3 0l0 19.5l-121.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 437.3l98.6 0l0 19.5l-98.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 409l90 0l0 19.5l-90 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 380.7l78.9 0l0 19.5l-78.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 352.4l78.2 0l0 19.5l-78.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 324.1l70 0l0 19.5l-70 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 295.8l63.2 0l0 19.5l-63.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 267.5l63.2 0l0 19.5l-63.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 239.2l62.7 0l0 19.5l-62.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 210.9l62.5 0l0 19.5l-62.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 182.6l46.7 0l0 19.5l-46.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="18" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 154.3l45.7 0l0 19.5l-45.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="19" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 126l27.1 0l0 19.5l-27.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="20" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 97.7l26.4 0l0 19.5l-26.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="21" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 69.4l19.8 0l0 19.5l-19.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="22" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<svg width="900" height="824" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 824">
+<rect width="900" height="824" x="0" y="0" fill="#ffffff"></rect>
+<path d="M156.5 65L156.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M265.5 65L265.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M374.5 65L374.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M483.5 65L483.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M592.5 65L592.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M701.5 65L701.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M810.5 65L810.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M156.5 744L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr0-cls-0"></path>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 729.8542)" fill="#111">    fastest-json-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 701.5625)" fill="#111">    clone-deep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 673.2708)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 644.9792)" fill="#111">    nanoclone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 616.6875)" fill="#111">    klona/json</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 588.3958)" fill="#111">    jsondiffpatch.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 560.1042)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 531.8125)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 503.5208)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 475.2292)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 446.9375)" fill="#111">    copy-anything</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 418.6458)" fill="#111">    JSON.stringify/parse</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 390.3542)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 362.0625)" fill="#111">    rfdc(circles)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 333.7708)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 305.4792)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.1875)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 248.8958)" fill="#111">    plain-object-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 220.6042)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.3125)" fill="#111">    just-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.0208)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.7292)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.4375)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1458)" fill="#111">    ramda.clone</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 752)" fill="#111">0</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(264.9333 752)" fill="#111">50.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(373.9467 752)" fill="#111">100.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(482.96 752)" fill="#111">150.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(591.9733 752)" fill="#111">200.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(700.9867 752)" fill="#111">250.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 752)" fill="#111">300.0k</text>
+<path d="M155.9 720.1l632.8 0l0 19.5l-632.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 691.8l349.2 0l0 19.5l-349.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 663.5l346.8 0l0 19.5l-346.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 635.2l161.2 0l0 19.5l-161.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 606.9l149.2 0l0 19.5l-149.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 578.6l145.4 0l0 19.5l-145.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 550.3l139.8 0l0 19.5l-139.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 522.1l133.4 0l0 19.5l-133.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 493.8l114.7 0l0 19.5l-114.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 465.5l111.5 0l0 19.5l-111.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 437.2l91.1 0l0 19.5l-91.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 408.9l87.7 0l0 19.5l-87.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 380.6l74.3 0l0 19.5l-74.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 352.3l73.1 0l0 19.5l-73.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 324l66.7 0l0 19.5l-66.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 295.7l60.9 0l0 19.5l-60.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 267.4l60.9 0l0 19.5l-60.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 239.1l60.2 0l0 19.5l-60.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 210.8l59.5 0l0 19.5l-59.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="18" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 182.6l44.3 0l0 19.5l-44.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="19" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 154.3l42.3 0l0 19.5l-42.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="20" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 126l26.1 0l0 19.5l-26.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="21" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 97.7l25.7 0l0 19.5l-25.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="22" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 69.4l18.2 0l0 19.5l-18.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="23" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
 <path d="M-86.6 -5l173.3 0l0 28l-173.3 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr0-cls-0"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">json • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/map-set-large.svg
+++ b/assets/bun/map-set-large.svg
@@ -1,50 +1,48 @@
 <svg width="900" height="572" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 572">
 <rect width="900" height="572" x="0" y="0" fill="#ffffff"></rect>
 <path d="M156.5 65L156.5 492" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr17-cls-34"></path>
-<path d="M265.5 65L265.5 492" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr17-cls-34"></path>
-<path d="M374.5 65L374.5 492" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr17-cls-34"></path>
-<path d="M483.5 65L483.5 492" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr17-cls-34"></path>
-<path d="M592.5 65L592.5 492" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr17-cls-34"></path>
-<path d="M701.5 65L701.5 492" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr17-cls-34"></path>
+<path d="M286.5 65L286.5 492" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr17-cls-34"></path>
+<path d="M417.5 65L417.5 492" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr17-cls-34"></path>
+<path d="M548.5 65L548.5 492" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr17-cls-34"></path>
+<path d="M679.5 65L679.5 492" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr17-cls-34"></path>
 <path d="M810.5 65L810.5 492" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr17-cls-34"></path>
 <path d="M156.5 492L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr17-cls-34"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 477.7667)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 449.3)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 420.8333)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 392.3667)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.9)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 335.4333)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 477.7667)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 449.3)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 420.8333)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 392.3667)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.9)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 335.4333)" fill="#111">    nanoclone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.9667)" fill="#111">    nano-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 278.5)" fill="#111">    structuredClone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 250.0333)" fill="#111">    @ungap/structured-clone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.5667)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 193.1)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 193.1)" fill="#111">    rfdc</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.6333)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 136.1667)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 136.1667)" fill="#111">    lodash.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.7)" fill="#111">    deepcopy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.2333)" fill="#111">    core-js/structured-clone</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 500)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(264.9333 500)" fill="#111">5.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(373.9467 500)" fill="#111">10.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(482.96 500)" fill="#111">15.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(591.9733 500)" fill="#111">20.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(700.9867 500)" fill="#111">25.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 500)" fill="#111">30.0k</text>
-<path d="M155.9 467.9l629.3 0l0 19.6l-629.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 439.5l616.4 0l0 19.6l-616.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 411l457.2 0l0 19.6l-457.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 382.5l442.5 0l0 19.6l-442.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 354.1l351.3 0l0 19.6l-351.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 325.6l305 0l0 19.6l-305 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 297.1l178.1 0l0 19.6l-178.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 268.7l158.6 0l0 19.6l-158.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 240.2l154.8 0l0 19.6l-154.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 211.7l152 0l0 19.6l-152 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 183.3l117.1 0l0 19.6l-117.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 154.8l117.1 0l0 19.6l-117.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 126.3l112.9 0l0 19.6l-112.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 97.9l89.3 0l0 19.6l-89.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 69.4l68 0l0 19.6l-68 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 500)" fill="#111">5.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 500)" fill="#111">10.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 500)" fill="#111">15.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 500)" fill="#111">20.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 500)" fill="#111">25.0k</text>
+<path d="M155.9 467.9l526.4 0l0 19.6l-526.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 439.5l509.8 0l0 19.6l-509.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 411l474.2 0l0 19.6l-474.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 382.5l426.6 0l0 19.6l-426.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 354.1l341.4 0l0 19.6l-341.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 325.6l261.2 0l0 19.6l-261.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 297.1l220.8 0l0 19.6l-220.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 268.7l187.4 0l0 19.6l-187.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 240.2l177.4 0l0 19.6l-177.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 211.7l153.7 0l0 19.6l-153.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 183.3l128.4 0l0 19.6l-128.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 154.8l128 0l0 19.6l-128 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 126.3l126.7 0l0 19.6l-126.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 97.9l95.8 0l0 19.6l-95.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 69.4l80.4 0l0 19.6l-80.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
 <path d="M-101.8 -5l203.5 0l0 28l-203.5 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr17-cls-34"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">map-set • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/map-set-small.svg
+++ b/assets/bun/map-set-small.svg
@@ -13,8 +13,8 @@
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 392.3667)" fill="#111">    klona</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.9)" fill="#111">    nanoclone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 335.4333)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.9667)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 278.5)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.9667)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 278.5)" fill="#111">    just-clone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 250.0333)" fill="#111">    structuredClone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.5667)" fill="#111">    @ungap/structured-clone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 193.1)" fill="#111">    rfdc(circles)</text>
@@ -28,21 +28,21 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 500)" fill="#111">150.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 500)" fill="#111">200.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 500)" fill="#111">250.0k</text>
-<path d="M155.9 467.9l540.6 0l0 19.6l-540.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 439.5l533.1 0l0 19.6l-533.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 411l410.4 0l0 19.6l-410.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 382.5l393 0l0 19.6l-393 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 354.1l238.1 0l0 19.6l-238.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 325.6l215.1 0l0 19.6l-215.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 297.1l180.1 0l0 19.6l-180.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 268.7l177.3 0l0 19.6l-177.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 240.2l171.5 0l0 19.6l-171.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 211.7l165.8 0l0 19.6l-165.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 183.3l148.5 0l0 19.6l-148.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 467.9l523.9 0l0 19.6l-523.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 439.5l456.2 0l0 19.6l-456.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 411l383.8 0l0 19.6l-383.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 382.5l380.7 0l0 19.6l-380.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 354.1l220.2 0l0 19.6l-220.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 325.6l212.2 0l0 19.6l-212.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 297.1l175.4 0l0 19.6l-175.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 268.7l173.8 0l0 19.6l-173.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 240.2l169.2 0l0 19.6l-169.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 211.7l164.9 0l0 19.6l-164.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 183.3l144.8 0l0 19.6l-144.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
 <path d="M155.9 154.8l144.4 0l0 19.6l-144.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 126.3l136.3 0l0 19.6l-136.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 97.9l102.6 0l0 19.6l-102.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 69.4l93.2 0l0 19.6l-93.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 126.3l133.1 0l0 19.6l-133.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 97.9l100.9 0l0 19.6l-100.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 69.4l71.7 0l0 19.6l-71.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
 <path d="M-102.7 -5l205.3 0l0 28l-205.3 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr16-cls-32"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">map-set • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/regexp-large.svg
+++ b/assets/bun/regexp-large.svg
@@ -1,56 +1,58 @@
-<svg width="900" height="628" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 628">
-<rect width="900" height="628" x="0" y="0" fill="#ffffff"></rect>
-<path d="M156.5 65L156.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M249.5 65L249.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M343.5 65L343.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M436.5 65L436.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M529.5 65L529.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M623.5 65L623.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M716.5 65L716.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M810.5 65L810.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M156.5 548L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr5-cls-10"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.7941)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 505.3824)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.9706)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 448.5588)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 420.1471)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.7353)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.3235)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.9118)" fill="#111">    core-js/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.5)" fill="#111">    ramda.clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 278.0882)" fill="#111">    deepcopy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.6765)" fill="#111">    lodash.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.2647)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.8529)" fill="#111">    klona/lite</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.4412)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 136.0294)" fill="#111">    rfdc(with RegExp)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.6176)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.2059)" fill="#111">    clone-deep</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 556)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(249.36 556)" fill="#111">3.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(342.8 556)" fill="#111">6.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(436.24 556)" fill="#111">9.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(529.68 556)" fill="#111">12.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(623.12 556)" fill="#111">15.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(716.56 556)" fill="#111">18.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 556)" fill="#111">21.0k</text>
-<path d="M155.9 524l597.9 0l0 19.6l-597.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 495.6l478.8 0l0 19.6l-478.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 467.2l291.1 0l0 19.6l-291.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 438.8l287 0l0 19.6l-287 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 410.3l188.4 0l0 19.6l-188.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 381.9l170.5 0l0 19.6l-170.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 353.5l131.7 0l0 19.6l-131.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 325.1l98.3 0l0 19.6l-98.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 296.7l77.5 0l0 19.6l-77.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 268.3l69.8 0l0 19.6l-69.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 239.9l66.6 0l0 19.6l-66.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 211.5l35.7 0l0 19.6l-35.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 183.1l35.4 0l0 19.6l-35.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 154.6l31.9 0l0 19.6l-31.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 126.2l31.5 0l0 19.6l-31.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 97.8l22 0l0 19.6l-22 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 69.4l18.5 0l0 19.6l-18.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<svg width="900" height="656" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 656">
+<rect width="900" height="656" x="0" y="0" fill="#ffffff"></rect>
+<path d="M156.5 65L156.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M249.5 65L249.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M343.5 65L343.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M436.5 65L436.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M529.5 65L529.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M623.5 65L623.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M716.5 65L716.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M810.5 65L810.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M156.5 576L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr5-cls-10"></path>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 561.8056)" fill="#111">    nanoclone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.4167)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 505.0278)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.6389)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 448.25)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 419.8611)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.4722)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.0833)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.6944)" fill="#111">    ramda.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.3056)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.9167)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.5278)" fill="#111">    just-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.1389)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.75)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.3611)" fill="#111">    rfdc(with RegExp)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.9722)" fill="#111">    jsondiffpatch.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.5833)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1944)" fill="#111">    clone-deep</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 584)" fill="#111">0</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(249.36 584)" fill="#111">3.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(342.8 584)" fill="#111">6.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(436.24 584)" fill="#111">9.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(529.68 584)" fill="#111">12.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(623.12 584)" fill="#111">15.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(716.56 584)" fill="#111">18.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 584)" fill="#111">21.0k</text>
+<path d="M155.9 552l593.8 0l0 19.6l-593.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 523.6l437.2 0l0 19.6l-437.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 495.2l275.8 0l0 19.6l-275.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 466.8l274.9 0l0 19.6l-274.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 438.5l174.6 0l0 19.6l-174.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 410.1l166.2 0l0 19.6l-166.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 381.7l129 0l0 19.6l-129 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 353.3l96.7 0l0 19.6l-96.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 324.9l74.8 0l0 19.6l-74.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 296.5l66.2 0l0 19.6l-66.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 268.1l65.3 0l0 19.6l-65.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 239.7l34.9 0l0 19.6l-34.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 211.3l33.1 0l0 19.6l-33.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 183l32.3 0l0 19.6l-32.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 154.6l30.2 0l0 19.6l-30.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 126.2l21.1 0l0 19.6l-21.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 97.8l20.5 0l0 19.6l-20.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 69.4l17.5 0l0 19.6l-17.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
 <path d="M-96.8 -5l193.6 0l0 28l-193.6 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr5-cls-10"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">regexp • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/bun/regexp-small.svg
+++ b/assets/bun/regexp-small.svg
@@ -1,52 +1,54 @@
-<svg width="900" height="628" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 628">
-<rect width="900" height="628" x="0" y="0" fill="#ffffff"></rect>
-<path d="M156.5 65L156.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
-<path d="M286.5 65L286.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
-<path d="M417.5 65L417.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
-<path d="M548.5 65L548.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
-<path d="M679.5 65L679.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
-<path d="M810.5 65L810.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
-<path d="M156.5 548L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr4-cls-8"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.7941)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 505.3824)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.9706)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 448.5588)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 420.1471)" fill="#111">    klona/lite</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.7353)" fill="#111">    rfdc(with RegExp)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.3235)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.9118)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.5)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 278.0882)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.6765)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.2647)" fill="#111">    clone-deep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.8529)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.4412)" fill="#111">    core-js/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 136.0294)" fill="#111">    ramda.clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.6176)" fill="#111">    lodash.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.2059)" fill="#111">    deepcopy</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 556)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 556)" fill="#111">50.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 556)" fill="#111">100.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 556)" fill="#111">150.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 556)" fill="#111">200.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 556)" fill="#111">250.0k</text>
-<path d="M155.9 524l603.7 0l0 19.6l-603.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 495.6l419.6 0l0 19.6l-419.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 467.2l201.7 0l0 19.6l-201.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 438.8l200 0l0 19.6l-200 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 410.3l199.6 0l0 19.6l-199.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 381.9l178.4 0l0 19.6l-178.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 353.5l160.7 0l0 19.6l-160.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 325.1l154.9 0l0 19.6l-154.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 296.7l142.8 0l0 19.6l-142.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 268.3l141.5 0l0 19.6l-141.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 239.9l125.1 0l0 19.6l-125.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 211.5l120.6 0l0 19.6l-120.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 183.1l116.4 0l0 19.6l-116.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 154.6l76.4 0l0 19.6l-76.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 126.2l71.3 0l0 19.6l-71.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 97.8l68 0l0 19.6l-68 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 69.4l54.6 0l0 19.6l-54.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<svg width="900" height="656" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 656">
+<rect width="900" height="656" x="0" y="0" fill="#ffffff"></rect>
+<path d="M156.5 65L156.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
+<path d="M286.5 65L286.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
+<path d="M417.5 65L417.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
+<path d="M548.5 65L548.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
+<path d="M679.5 65L679.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
+<path d="M810.5 65L810.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
+<path d="M156.5 576L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr4-cls-8"></path>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 561.8056)" fill="#111">    nanoclone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.4167)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 505.0278)" fill="#111">    just-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.6389)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 448.25)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 419.8611)" fill="#111">    rfdc(with RegExp)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.4722)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.0833)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.6944)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.3056)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.9167)" fill="#111">    jsondiffpatch.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.5278)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.1389)" fill="#111">    clone-deep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.75)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.3611)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.9722)" fill="#111">    ramda.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.5833)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1944)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 584)" fill="#111">0</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 584)" fill="#111">50.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 584)" fill="#111">100.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 584)" fill="#111">150.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 584)" fill="#111">200.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 584)" fill="#111">250.0k</text>
+<path d="M155.9 552l615.6 0l0 19.6l-615.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 523.6l417.1 0l0 19.6l-417.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 495.2l204.6 0l0 19.6l-204.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 466.8l184.3 0l0 19.6l-184.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 438.5l180.9 0l0 19.6l-180.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 410.1l169.8 0l0 19.6l-169.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 381.7l149.1 0l0 19.6l-149.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 353.3l148 0l0 19.6l-148 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 324.9l139 0l0 19.6l-139 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 296.5l134 0l0 19.6l-134 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 268.1l122.2 0l0 19.6l-122.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 239.7l117.4 0l0 19.6l-117.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 211.3l114.2 0l0 19.6l-114.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 183l109.5 0l0 19.6l-109.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 154.6l77.3 0l0 19.6l-77.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 126.2l69.1 0l0 19.6l-69.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 97.8l62 0l0 19.6l-62 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 69.4l54.5 0l0 19.6l-54.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
 <path d="M-97.7 -5l195.4 0l0 28l-195.4 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr4-cls-8"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">regexp • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/array-buffer-large.svg
+++ b/assets/node/array-buffer-large.svg
@@ -7,10 +7,10 @@
 <path d="M679.5 65L679.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
 <path d="M810.5 65L810.5 296" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr11-cls-22"></path>
 <path d="M156.5 296L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr11-cls-22"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 281.5625)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 252.6875)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 223.8125)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 194.9375)" fill="#111">    rfdc(with ArrayBuffer)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 281.5625)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 252.6875)" fill="#111">    rfdc(with ArrayBuffer)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 223.8125)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 194.9375)" fill="#111">    klona</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 166.0625)" fill="#111">    core-js/structured-clone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 137.1875)" fill="#111">    es-toolkit.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 108.3125)" fill="#111">    structuredClone</text>
@@ -23,10 +23,10 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 304)" fill="#111">50</text>
 <path d="M155.9 271.6l641 0l0 19.9l-641 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
 <path d="M155.9 242.7l641 0l0 19.9l-641 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
-<path d="M155.9 213.9l641 0l0 19.9l-641 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
-<path d="M155.9 185l641 0l0 19.9l-641 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
+<path d="M155.9 213.9l627.9 0l0 19.9l-627.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
+<path d="M155.9 185l627.9 0l0 19.9l-627.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
 <path d="M155.9 156.1l614.8 0l0 19.9l-614.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
-<path d="M155.9 127.2l353.2 0l0 19.9l-353.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
+<path d="M155.9 127.2l340.1 0l0 19.9l-340.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
 <path d="M155.9 98.4l183.1 0l0 19.9l-183.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
 <path d="M155.9 69.5l183.1 0l0 19.9l-183.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr11-cls-23"></path>
 <path d="M-115.8 -5l231.6 0l0 28l-231.6 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr11-cls-22"></path>

--- a/assets/node/array-buffer-small.svg
+++ b/assets/node/array-buffer-small.svg
@@ -11,9 +11,9 @@
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 281.5625)" fill="#111">    rfdc(with ArrayBuffer)</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 252.6875)" fill="#111">    nano-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 223.8125)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 194.9375)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 166.0625)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 137.1875)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 194.9375)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 166.0625)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 137.1875)" fill="#111">    fast-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 108.3125)" fill="#111">    core-js/structured-clone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.4375)" fill="#111">    es-toolkit.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 304)" fill="#111">0</text>
@@ -23,14 +23,14 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(591.9733 304)" fill="#111">40.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(700.9867 304)" fill="#111">50.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 304)" fill="#111">60.0k</text>
-<path d="M155.9 271.6l580.7 0l0 19.9l-580.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 242.7l547.7 0l0 19.9l-547.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 213.9l510.9 0l0 19.9l-510.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 185l466.8 0l0 19.9l-466.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 156.1l448.4 0l0 19.9l-448.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 127.2l439.7 0l0 19.9l-439.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 98.4l359.9 0l0 19.9l-359.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
-<path d="M155.9 69.5l336.4 0l0 19.9l-336.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 271.6l548.6 0l0 19.9l-548.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 242.7l524.7 0l0 19.9l-524.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 213.9l509.5 0l0 19.9l-509.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 185l441.1 0l0 19.9l-441.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 156.1l440.4 0l0 19.9l-440.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 127.2l431.4 0l0 19.9l-431.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 98.4l367.7 0l0 19.9l-367.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
+<path d="M155.9 69.5l311.5 0l0 19.9l-311.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr10-cls-21"></path>
 <path d="M-116.7 -5l233.4 0l0 28l-233.4 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr10-cls-20"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">array-buffer • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/buffer-large.svg
+++ b/assets/node/buffer-large.svg
@@ -8,12 +8,12 @@
 <path d="M697.5 65L697.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr13-cls-26"></path>
 <path d="M810.5 65L810.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr13-cls-26"></path>
 <path d="M135.5 268L135.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr13-cls-26"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 253.5)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 224.5)" fill="#111">    rfdc</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 195.5)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 166.5)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 137.5)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 108.5)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 253.5)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 224.5)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 195.5)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 166.5)" fill="#111">    rfdc(circles)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 137.5)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 108.5)" fill="#111">    nano-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 79.5)" fill="#111">    deepcopy</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(135 276)" fill="#111">0</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(247.5 276)" fill="#111">10</text>
@@ -22,13 +22,13 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(585 276)" fill="#111">40</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(697.5 276)" fill="#111">50</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 276)" fill="#111">60</text>
-<path d="M135 243.5l596.3 0l0 20l-596.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
-<path d="M135 214.5l596.3 0l0 20l-596.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
-<path d="M135 185.5l596.3 0l0 20l-596.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
-<path d="M135 156.5l596.3 0l0 20l-596.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
-<path d="M135 127.5l596.3 0l0 20l-596.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
-<path d="M135 98.5l573.8 0l0 20l-573.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
-<path d="M135 69.5l315 0l0 20l-315 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<path d="M135 243.5l585 0l0 20l-585 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<path d="M135 214.5l585 0l0 20l-585 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<path d="M135 185.5l585 0l0 20l-585 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<path d="M135 156.5l585 0l0 20l-585 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<path d="M135 127.5l585 0l0 20l-585 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<path d="M135 98.5l585 0l0 20l-585 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
+<path d="M135 69.5l303.8 0l0 20l-303.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr13-cls-27"></path>
 <path d="M-92.3 -5l184.6 0l0 28l-184.6 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr13-cls-26"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">buffer • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/buffer-small.svg
+++ b/assets/node/buffer-small.svg
@@ -10,11 +10,11 @@
 <path d="M810.5 65L810.5 268" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr12-cls-24"></path>
 <path d="M135.5 268L135.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr12-cls-24"></path>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 253.5)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 224.5)" fill="#111">    rfdc</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 195.5)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 166.5)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 137.5)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 108.5)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 224.5)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 195.5)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 166.5)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 137.5)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 108.5)" fill="#111">    clone(circular)</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(131 79.5)" fill="#111">    deepcopy</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(135 276)" fill="#111">0</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(231.4286 276)" fill="#111">10.0k</text>
@@ -24,13 +24,13 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(617.1429 276)" fill="#111">50.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(713.5714 276)" fill="#111">60.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 276)" fill="#111">70.0k</text>
-<path d="M135 243.5l636.6 0l0 20l-636.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
-<path d="M135 214.5l631.2 0l0 20l-631.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
-<path d="M135 185.5l618.3 0l0 20l-618.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
-<path d="M135 156.5l480.8 0l0 20l-480.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
-<path d="M135 127.5l479.3 0l0 20l-479.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
-<path d="M135 98.5l446.6 0l0 20l-446.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
-<path d="M135 69.5l305.9 0l0 20l-305.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 243.5l647.6 0l0 20l-647.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 214.5l622.1 0l0 20l-622.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 185.5l614.7 0l0 20l-614.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 156.5l533.2 0l0 20l-533.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 127.5l490.1 0l0 20l-490 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 98.5l466.6 0l0 20l-466.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
+<path d="M135 69.5l310.2 0l0 20l-310.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr12-cls-25"></path>
 <path d="M-93.2 -5l186.4 0l0 28l-186.4 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr12-cls-24"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">buffer • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/buffer-zero-copy-large.svg
+++ b/assets/node/buffer-zero-copy-large.svg
@@ -15,8 +15,8 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(540 136)" fill="#111">600.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(675 136)" fill="#111">800.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 136)" fill="#111">1.0M</text>
-<path d="M135 101.4l656 0l0 21.7l-656 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr15-cls-31"></path>
-<path d="M135 69.9l250.6 0l0 21.7l-250.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr15-cls-31"></path>
+<path d="M135 101.4l622 0l0 21.7l-622 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr15-cls-31"></path>
+<path d="M135 69.9l250.7 0l0 21.7l-250.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr15-cls-31"></path>
 <path d="M-134.9 -5l269.7 0l0 28l-269.7 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr15-cls-30"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">buffer-zero-copy • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/buffer-zero-copy-small.svg
+++ b/assets/node/buffer-zero-copy-small.svg
@@ -15,8 +15,8 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(540 136)" fill="#111">600.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(675 136)" fill="#111">800.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 136)" fill="#111">1.0M</text>
-<path d="M135 101.4l638.3 0l0 21.7l-638.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr14-cls-29"></path>
-<path d="M135 69.9l254.5 0l0 21.7l-254.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr14-cls-29"></path>
+<path d="M135 101.4l617.1 0l0 21.7l-617.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr14-cls-29"></path>
+<path d="M135 69.9l258.9 0l0 21.7l-258.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr14-cls-29"></path>
 <path d="M-135.8 -5l271.5 0l0 28l-271.5 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr14-cls-28"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">buffer-zero-copy • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/custom-class-large.svg
+++ b/assets/node/custom-class-large.svg
@@ -25,16 +25,16 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(593.5333 360)" fill="#111">8.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(701.7667 360)" fill="#111">10.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 360)" fill="#111">12.0k</text>
-<path d="M160.6 327.7l603 0l0 19.8l-603 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 299l386.4 0l0 19.8l-386.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 270.3l372.9 0l0 19.8l-372.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 241.6l271.3 0l0 19.8l-271.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 212.9l187 0l0 19.8l-187 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 184.2l154.8 0l0 19.8l-154.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 155.5l89.7 0l0 19.8l-89.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 126.8l61.3 0l0 19.8l-61.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 98.1l41.1 0l0 19.8l-41.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
-<path d="M160.6 69.4l20.7 0l0 19.8l-20.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 327.7l593.3 0l0 19.8l-593.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 299l378.1 0l0 19.8l-378.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 270.3l342.8 0l0 19.8l-342.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 241.6l266 0l0 19.8l-266 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 212.9l166.4 0l0 19.8l-166.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 184.2l153.6 0l0 19.8l-153.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 155.5l87.8 0l0 19.8l-87.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 126.8l59.5 0l0 19.8l-59.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 98.1l38.4 0l0 19.8l-38.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
+<path d="M160.6 69.4l20.2 0l0 19.8l-20.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr9-cls-19"></path>
 <path d="M-121.7 -5l243.5 0l0 28l-243.5 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr9-cls-18"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">custom-class • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/custom-class-small.svg
+++ b/assets/node/custom-class-small.svg
@@ -10,8 +10,8 @@
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 308.95)" fill="#111">    klona/lite</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 280.25)" fill="#111">    klona</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 251.55)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 222.85)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 194.15)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 222.85)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 194.15)" fill="#111">    fast-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 165.45)" fill="#111">    lodash.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 136.75)" fill="#111">    clone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(156.6 108.05)" fill="#111">    clone(circular)</text>
@@ -21,16 +21,16 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(485.3 360)" fill="#111">2.0M</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(647.65 360)" fill="#111">3.0M</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 360)" fill="#111">4.0M</text>
-<path d="M160.6 327.7l617.8 0l0 19.8l-617.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 299l345 0l0 19.8l-345 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 270.3l325.2 0l0 19.8l-325.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 241.6l247.5 0l0 19.8l-247.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 212.9l181 0l0 19.8l-181 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 184.2l161.6 0l0 19.8l-161.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 155.5l104.4 0l0 19.8l-104.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 126.8l61.3 0l0 19.8l-61.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 98.1l53.1 0l0 19.8l-53.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
-<path d="M160.6 69.4l37.7 0l0 19.8l-37.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 327.7l603.8 0l0 19.8l-603.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 299l339 0l0 19.8l-339 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 270.3l314 0l0 19.8l-314 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 241.6l250.5 0l0 19.8l-250.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 212.9l164.9 0l0 19.8l-164.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 184.2l156.1 0l0 19.8l-156.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 155.5l101.3 0l0 19.8l-101.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 126.8l58.7 0l0 19.8l-58.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 98.1l51.1 0l0 19.8l-51.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
+<path d="M160.6 69.4l35.9 0l0 19.8l-35.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr8-cls-17"></path>
 <path d="M-122.6 -5l245.3 0l0 28l-245.3 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr8-cls-16"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">custom-class • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/date-large.svg
+++ b/assets/node/date-large.svg
@@ -1,56 +1,58 @@
-<svg width="900" height="656" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 656">
-<rect width="900" height="656" x="0" y="0" fill="#ffffff"></rect>
-<path d="M156.5 65L156.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
-<path d="M265.5 65L265.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
-<path d="M374.5 65L374.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
-<path d="M483.5 65L483.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
-<path d="M592.5 65L592.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
-<path d="M701.5 65L701.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
-<path d="M810.5 65L810.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
-<path d="M156.5 576L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr7-cls-14"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 561.8056)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.4167)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 505.0278)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.6389)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 448.25)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 419.8611)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.4722)" fill="#111">    deepcopy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.0833)" fill="#111">    lodash.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.6944)" fill="#111">    rfdc</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.3056)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.9167)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.5278)" fill="#111">    ramda.clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.1389)" fill="#111">    klona/lite</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.75)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.3611)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.9722)" fill="#111">    core-js/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.5833)" fill="#111">    clone-deep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1944)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 584)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(264.9333 584)" fill="#111">5.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(373.9467 584)" fill="#111">10.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(482.96 584)" fill="#111">15.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(591.9733 584)" fill="#111">20.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(700.9867 584)" fill="#111">25.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 584)" fill="#111">30.0k</text>
-<path d="M155.9 552l583.7 0l0 19.6l-583.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 523.6l433.4 0l0 19.6l-433.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 495.2l426 0l0 19.6l-426 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 466.8l341.2 0l0 19.6l-341.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 438.5l331 0l0 19.6l-331 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 410.1l327.6 0l0 19.6l-327.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 381.7l145 0l0 19.6l-145 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 353.3l101.8 0l0 19.6l-101.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 324.9l87.1 0l0 19.6l-87.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 296.5l77.8 0l0 19.6l-77.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 268.1l71.9 0l0 19.6l-71.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 239.7l70.1 0l0 19.6l-70.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 211.3l63.2 0l0 19.6l-63.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 183l63 0l0 19.6l-63 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 154.6l49.8 0l0 19.6l-49.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 126.2l46.3 0l0 19.6l-46.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 97.8l28.6 0l0 19.6l-28.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
-<path d="M155.9 69.4l10.4 0l0 19.6l-10.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<svg width="900" height="684" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 684">
+<rect width="900" height="684" x="0" y="0" fill="#ffffff"></rect>
+<path d="M156.5 65L156.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
+<path d="M265.5 65L265.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
+<path d="M374.5 65L374.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
+<path d="M483.5 65L483.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
+<path d="M592.5 65L592.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
+<path d="M701.5 65L701.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
+<path d="M810.5 65L810.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr7-cls-14"></path>
+<path d="M156.5 604L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr7-cls-14"></path>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 589.8158)" fill="#111">    nanoclone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 561.4474)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.0789)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 504.7105)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.3421)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 447.9737)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 419.6053)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.2368)" fill="#111">    jsondiffpatch.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 362.8684)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.5)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.1316)" fill="#111">    rfdc(circles)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.7632)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.3947)" fill="#111">    ramda.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.0263)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.6579)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.2895)" fill="#111">    just-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.9211)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.5526)" fill="#111">    clone-deep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1842)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 612)" fill="#111">0</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(264.9333 612)" fill="#111">5.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(373.9467 612)" fill="#111">10.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(482.96 612)" fill="#111">15.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(591.9733 612)" fill="#111">20.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(700.9867 612)" fill="#111">25.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 612)" fill="#111">30.0k</text>
+<path d="M155.9 580l594.7 0l0 19.6l-594.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 551.7l428.1 0l0 19.6l-428.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 523.3l418.2 0l0 19.6l-418.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 494.9l337.3 0l0 19.6l-337.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 466.6l317.9 0l0 19.6l-317.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 438.2l316 0l0 19.6l-316 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 409.8l138.1 0l0 19.6l-138.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 381.4l128.1 0l0 19.6l-128.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 353.1l100.6 0l0 19.6l-100.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 324.7l86.6 0l0 19.6l-86.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 296.3l77.5 0l0 19.6l-77.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 268l71.5 0l0 19.6l-71.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 239.6l67.7 0l0 19.6l-67.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 211.2l62.1 0l0 19.6l-62.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 182.9l59.9 0l0 19.6l-59.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 154.5l49.6 0l0 19.6l-49.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 126.1l45.2 0l0 19.6l-45.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 97.8l28.1 0l0 19.6l-28.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
+<path d="M155.9 69.4l9.9 0l0 19.6l-9.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="18" ecmeta_ssr_type="chart" class="zr7-cls-15"></path>
 <path d="M-86.8 -5l173.6 0l0 28l-173.6 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr7-cls-14"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">date • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/date-small.svg
+++ b/assets/node/date-small.svg
@@ -1,54 +1,60 @@
-<svg width="900" height="656" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 656">
-<rect width="900" height="656" x="0" y="0" fill="#ffffff"></rect>
-<path d="M156.5 65L156.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
-<path d="M286.5 65L286.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
-<path d="M417.5 65L417.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
-<path d="M548.5 65L548.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
-<path d="M679.5 65L679.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
-<path d="M810.5 65L810.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
-<path d="M156.5 576L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr6-cls-12"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 561.8056)" fill="#111">    rfdc</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.4167)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 505.0278)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.6389)" fill="#111">    klona/lite</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 448.25)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 419.8611)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.4722)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.0833)" fill="#111">    clone-deep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.6944)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.3056)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.9167)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.5278)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.1389)" fill="#111">    lodash.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.75)" fill="#111">    deepcopy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.3611)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.9722)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.5833)" fill="#111">    ramda.clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1944)" fill="#111">    core-js/structured-clone</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 584)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 584)" fill="#111">50.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 584)" fill="#111">100.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 584)" fill="#111">150.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 584)" fill="#111">200.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 584)" fill="#111">250.0k</text>
-<path d="M155.9 552l557.8 0l0 19.6l-557.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 523.6l549.4 0l0 19.6l-549.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 495.2l420.6 0l0 19.6l-420.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 466.8l404.3 0l0 19.6l-404.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 438.5l380 0l0 19.6l-380 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 410.1l342.9 0l0 19.6l-342.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 381.7l260.3 0l0 19.6l-260.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 353.3l196.6 0l0 19.6l-196.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 324.9l195.5 0l0 19.6l-195.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 296.5l185.8 0l0 19.6l-185.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 268.1l136.1 0l0 19.6l-136.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 239.7l133.5 0l0 19.6l-133.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 211.3l81.2 0l0 19.6l-81.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 183l75.2 0l0 19.6l-75.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 154.6l66.8 0l0 19.6l-66.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 126.2l56.7 0l0 19.6l-56.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 97.8l49.1 0l0 19.6l-49.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
-<path d="M155.9 69.4l37.2 0l0 19.6l-37.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<svg width="900" height="684" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 684">
+<rect width="900" height="684" x="0" y="0" fill="#ffffff"></rect>
+<path d="M156.5 65L156.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M249.5 65L249.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M343.5 65L343.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M436.5 65L436.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M529.5 65L529.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M623.5 65L623.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M716.5 65L716.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M810.5 65L810.5 604" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr6-cls-12"></path>
+<path d="M156.5 604L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr6-cls-12"></path>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 589.8158)" fill="#111">    jsondiffpatch.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 561.4474)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.0789)" fill="#111">    rfdc(circles)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 504.7105)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.3421)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 447.9737)" fill="#111">    nanoclone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 419.6053)" fill="#111">    just-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.2368)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 362.8684)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.5)" fill="#111">    clone-deep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.1316)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.7632)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.3947)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.0263)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.6579)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.2895)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.9211)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.5526)" fill="#111">    ramda.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1842)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 612)" fill="#111">0</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(249.36 612)" fill="#111">50.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(342.8 612)" fill="#111">100.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(436.24 612)" fill="#111">150.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(529.68 612)" fill="#111">200.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(623.12 612)" fill="#111">250.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(716.56 612)" fill="#111">300.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 612)" fill="#111">350.0k</text>
+<path d="M155.9 580l563.6 0l0 19.6l-563.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 551.7l417.6 0l0 19.6l-417.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 523.3l385.3 0l0 19.6l-385.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 494.9l294 0l0 19.6l-294 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 466.6l280.8 0l0 19.6l-280.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 438.2l270.4 0l0 19.6l-270.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 409.8l248.9 0l0 19.6l-248.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 381.4l196.3 0l0 19.6l-196.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 353.1l138.3 0l0 19.6l-138.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 324.7l130 0l0 19.6l-130 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 296.3l125.3 0l0 19.6l-125.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 268l94.7 0l0 19.6l-94.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 239.6l92.8 0l0 19.6l-92.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 211.2l56.3 0l0 19.6l-56.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 182.9l53.6 0l0 19.6l-53.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 154.5l47.5 0l0 19.6l-47.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 126.1l39.5 0l0 19.6l-39.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 97.8l33.9 0l0 19.6l-33.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
+<path d="M155.9 69.4l26.2 0l0 19.6l-26.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="18" ecmeta_ssr_type="chart" class="zr6-cls-13"></path>
 <path d="M-87.7 -5l175.4 0l0 28l-175.4 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr6-cls-12"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">date • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/json-circular-large.svg
+++ b/assets/node/json-circular-large.svg
@@ -1,11 +1,10 @@
 <svg width="900" height="488" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 488">
 <rect width="900" height="488" x="0" y="0" fill="#ffffff"></rect>
 <path d="M156.5 65L156.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr3-cls-6"></path>
-<path d="M265.5 65L265.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr3-cls-6"></path>
-<path d="M374.5 65L374.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr3-cls-6"></path>
-<path d="M483.5 65L483.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr3-cls-6"></path>
-<path d="M592.5 65L592.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr3-cls-6"></path>
-<path d="M701.5 65L701.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr3-cls-6"></path>
+<path d="M286.5 65L286.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr3-cls-6"></path>
+<path d="M417.5 65L417.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr3-cls-6"></path>
+<path d="M548.5 65L548.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr3-cls-6"></path>
+<path d="M679.5 65L679.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr3-cls-6"></path>
 <path d="M810.5 65L810.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr3-cls-6"></path>
 <path d="M156.5 408L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr3-cls-6"></path>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 393.7083)" fill="#111">    rfdc(circles)</text>
@@ -21,24 +20,23 @@
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.875)" fill="#111">    clone(circular)</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.2917)" fill="#111">    ramda.clone</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 416)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(264.9333 416)" fill="#111">500</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(373.9467 416)" fill="#111">1.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(482.96 416)" fill="#111">1.5k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(591.9733 416)" fill="#111">2.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(700.9867 416)" fill="#111">2.5k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 416)" fill="#111">3.0k</text>
-<path d="M155.9 383.8l577.6 0l0 19.7l-577.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 355.3l521.7 0l0 19.7l-521.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 326.7l408.8 0l0 19.7l-408.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 298.1l325.7 0l0 19.7l-325.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 269.5l231.5 0l0 19.7l-231.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 240.9l164.4 0l0 19.7l-164.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 212.3l162.4 0l0 19.7l-162.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 183.8l134.5 0l0 19.7l-134.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 155.2l76.3 0l0 19.7l-76.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 126.6l63.4 0l0 19.7l-63.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 98l43.2 0l0 19.7l-43.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
-<path d="M155.9 69.4l14.8 0l0 19.7l-14.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 416)" fill="#111">500</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 416)" fill="#111">1.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 416)" fill="#111">1.5k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 416)" fill="#111">2.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 416)" fill="#111">2.5k</text>
+<path d="M155.9 383.8l647.5 0l0 19.7l-647.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 355.3l616.4 0l0 19.7l-616.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 326.7l473 0l0 19.7l-473 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 298.1l406.1 0l0 19.7l-406.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 269.5l275 0l0 19.7l-275 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 240.9l195.4 0l0 19.7l-195.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 212.3l191.8 0l0 19.7l-191.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 183.8l159.1 0l0 19.7l-159.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 155.2l89.5 0l0 19.7l-89.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 126.6l71.7 0l0 19.7l-71.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 98l48.1 0l0 19.7l-48.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
+<path d="M155.9 69.4l16.5 0l0 19.7l-16.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr3-cls-7"></path>
 <path d="M-117.7 -5l235.4 0l0 28l-235.4 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr3-cls-6"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">json-circular • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/json-circular-small.svg
+++ b/assets/node/json-circular-small.svg
@@ -6,15 +6,15 @@
 <path d="M646.5 65L646.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
 <path d="M810.5 65L810.5 408" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr2-cls-4"></path>
 <path d="M156.5 408L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr2-cls-4"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 393.7083)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 365.125)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 336.5417)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 307.9583)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 393.7083)" fill="#111">    rfdc(circles)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 365.125)" fill="#111">    nanoclone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 336.5417)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 307.9583)" fill="#111">    fast-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 279.375)" fill="#111">    es-toolkit.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 250.7917)" fill="#111">    lodash.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 222.2083)" fill="#111">    deepcopy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 193.625)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 165.0417)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 193.625)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 165.0417)" fill="#111">    @ungap/structured-clone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 136.4583)" fill="#111">    clone(circular)</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.875)" fill="#111">    core-js/structured-clone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.2917)" fill="#111">    ramda.clone</text>
@@ -23,18 +23,18 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(482.96 416)" fill="#111">2.0M</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(646.48 416)" fill="#111">3.0M</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 416)" fill="#111">4.0M</text>
-<path d="M155.9 383.8l653 0l0 19.7l-653 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 355.3l622.3 0l0 19.7l-622.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 326.7l439.8 0l0 19.7l-439.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 298.1l425 0l0 19.7l-425 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 269.5l245.7 0l0 19.7l-245.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 240.9l159.9 0l0 19.7l-159.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 212.3l97.8 0l0 19.7l-97.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 183.8l89.8 0l0 19.7l-89.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 155.2l88 0l0 19.7l-88 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 126.6l60.2 0l0 19.7l-60.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 98l50.4 0l0 19.7l-50.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
-<path d="M155.9 69.4l45.1 0l0 19.7l-45.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 383.8l623 0l0 19.7l-623 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 355.3l611.2 0l0 19.7l-611.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 326.7l446 0l0 19.7l-446 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 298.1l418.8 0l0 19.7l-418.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 269.5l235.2 0l0 19.7l-235.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 240.9l151.4 0l0 19.7l-151.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 212.3l99.5 0l0 19.7l-99.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 183.8l87.7 0l0 19.7l-87.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 155.2l84.5 0l0 19.7l-84.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 126.6l59.9 0l0 19.7l-59.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 98l54.3 0l0 19.7l-54.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
+<path d="M155.9 69.4l44.5 0l0 19.7l-44.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr2-cls-5"></path>
 <path d="M-118.6 -5l237.2 0l0 28l-237.2 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr2-cls-4"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">json-circular • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/json-large.svg
+++ b/assets/node/json-large.svg
@@ -1,64 +1,66 @@
-<svg width="900" height="796" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 796">
-<rect width="900" height="796" x="0" y="0" fill="#ffffff"></rect>
-<path d="M156.5 65L156.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M286.5 65L286.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M417.5 65L417.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M548.5 65L548.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M679.5 65L679.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M810.5 65L810.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
-<path d="M156.5 716L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr1-cls-2"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 701.8478)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 673.5435)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 645.2391)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 616.9348)" fill="#111">    klona/json</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 588.6304)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 560.3261)" fill="#111">    klona/lite</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 532.0217)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 503.7174)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 475.413)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 447.1087)" fill="#111">    fastest-json-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 418.8043)" fill="#111">    lodash.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 390.5)" fill="#111">    rfdc</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 362.1957)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 333.8913)" fill="#111">    deepcopy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 305.587)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.2826)" fill="#111">    core-js/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 248.9783)" fill="#111">    clone-deep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 220.6739)" fill="#111">    JSON.stringify/parse</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.3696)" fill="#111">    plain-object-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.0652)" fill="#111">    ramda.clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.7609)" fill="#111">    copy-anything</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.4565)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1522)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 724)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 724)" fill="#111">3.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 724)" fill="#111">6.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 724)" fill="#111">9.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 724)" fill="#111">12.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 724)" fill="#111">15.0k</text>
-<path d="M155.9 692.1l624.6 0l0 19.5l-624.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 663.8l471.1 0l0 19.5l-471.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 635.5l454.1 0l0 19.5l-454.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 607.2l242.7 0l0 19.5l-242.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 578.9l226.5 0l0 19.5l-226.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 550.6l215.6 0l0 19.5l-215.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 522.3l206.3 0l0 19.5l-206.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 494l200.7 0l0 19.5l-200.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 465.6l197.1 0l0 19.5l-197.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 437.3l175.4 0l0 19.5l-175.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 409l147.3 0l0 19.5l-147.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 380.7l123.2 0l0 19.5l-123.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 352.4l104.6 0l0 19.5l-104.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 324.1l93.4 0l0 19.5l-93.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 295.8l84.5 0l0 19.5l-84.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 267.5l80.2 0l0 19.5l-80.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 239.2l75.5 0l0 19.5l-75.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 210.9l60.7 0l0 19.5l-60.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 182.6l40.7 0l0 19.5l-40.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="18" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 154.3l29.5 0l0 19.5l-29.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="19" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 126l22.3 0l0 19.5l-22.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="20" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 97.7l18.5 0l0 19.5l-18.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="21" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
-<path d="M155.9 69.4l15.4 0l0 19.5l-15.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="22" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<svg width="900" height="824" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 824">
+<rect width="900" height="824" x="0" y="0" fill="#ffffff"></rect>
+<path d="M156.5 65L156.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
+<path d="M286.5 65L286.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
+<path d="M417.5 65L417.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
+<path d="M548.5 65L548.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
+<path d="M679.5 65L679.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
+<path d="M810.5 65L810.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr1-cls-2"></path>
+<path d="M156.5 744L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr1-cls-2"></path>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 729.8542)" fill="#111">    nanoclone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 701.5625)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 673.2708)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 644.9792)" fill="#111">    klona/json</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 616.6875)" fill="#111">    jsondiffpatch.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 588.3958)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 560.1042)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 531.8125)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 503.5208)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 475.2292)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 446.9375)" fill="#111">    fastest-json-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 418.6458)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 390.3542)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 362.0625)" fill="#111">    rfdc(circles)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 333.7708)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 305.4792)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.1875)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 248.8958)" fill="#111">    clone-deep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 220.6042)" fill="#111">    JSON.stringify/parse</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.3125)" fill="#111">    plain-object-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.0208)" fill="#111">    ramda.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.7292)" fill="#111">    copy-anything</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.4375)" fill="#111">    just-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1458)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 752)" fill="#111">0</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 752)" fill="#111">3.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 752)" fill="#111">6.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 752)" fill="#111">9.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 752)" fill="#111">12.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 752)" fill="#111">15.0k</text>
+<path d="M155.9 720.1l612.4 0l0 19.5l-612.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 691.8l466.5 0l0 19.5l-466.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 663.5l423.8 0l0 19.5l-423.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 635.2l235.5 0l0 19.5l-235.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 606.9l231.7 0l0 19.5l-231.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 578.6l229.1 0l0 19.5l-229.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 550.3l206.9 0l0 19.5l-206.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 522.1l200.7 0l0 19.5l-200.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 493.8l194.9 0l0 19.5l-194.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 465.5l186.5 0l0 19.5l-186.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 437.2l165.8 0l0 19.5l-165.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 408.9l141.8 0l0 19.5l-141.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 380.6l117.9 0l0 19.5l-117.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 352.3l105.2 0l0 19.5l-105.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 324l88.6 0l0 19.5l-88.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 295.7l81.5 0l0 19.5l-81.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 267.4l81 0l0 19.5l-81 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 239.1l74 0l0 19.5l-74 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 210.8l57.6 0l0 19.5l-57.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="18" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 182.6l41.4 0l0 19.5l-41.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="19" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 154.3l25.1 0l0 19.5l-25.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="20" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 126l21.9 0l0 19.5l-21.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="21" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 97.7l18.1 0l0 19.5l-18.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="22" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
+<path d="M155.9 69.4l15 0l0 19.5l-15 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="23" ecmeta_ssr_type="chart" class="zr1-cls-3"></path>
 <path d="M-85.7 -5l171.5 0l0 28l-171.5 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr1-cls-2"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">json • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/json-small.svg
+++ b/assets/node/json-small.svg
@@ -1,68 +1,70 @@
-<svg width="900" height="796" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 796">
-<rect width="900" height="796" x="0" y="0" fill="#ffffff"></rect>
-<path d="M156.5 65L156.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M249.5 65L249.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M343.5 65L343.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M436.5 65L436.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M529.5 65L529.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M623.5 65L623.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M716.5 65L716.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M810.5 65L810.5 716" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
-<path d="M156.5 716L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr0-cls-0"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 701.8478)" fill="#111">    klona/json</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 673.5435)" fill="#111">    klona/lite</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 645.2391)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 616.9348)" fill="#111">    fastest-json-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 588.6304)" fill="#111">    rfdc</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 560.3261)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 532.0217)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 503.7174)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 475.413)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 447.1087)" fill="#111">    clone-deep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 418.8043)" fill="#111">    JSON.stringify/parse</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 390.5)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 362.1957)" fill="#111">    plain-object-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 333.8913)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 305.587)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.2826)" fill="#111">    lodash.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 248.9783)" fill="#111">    copy-anything</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 220.6739)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.3696)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.0652)" fill="#111">    deepcopy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.7609)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.4565)" fill="#111">    core-js/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1522)" fill="#111">    ramda.clone</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 724)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(249.36 724)" fill="#111">50.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(342.8 724)" fill="#111">100.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(436.24 724)" fill="#111">150.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(529.68 724)" fill="#111">200.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(623.12 724)" fill="#111">250.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(716.56 724)" fill="#111">300.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 724)" fill="#111">350.0k</text>
-<path d="M155.9 692.1l597.6 0l0 19.5l-597.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 663.8l549.6 0l0 19.5l-549.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 635.5l506.8 0l0 19.5l-506.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 607.2l410.6 0l0 19.5l-410.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 578.9l314 0l0 19.5l-314 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 550.6l271.7 0l0 19.5l-271.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 522.3l259.8 0l0 19.5l-259.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 494l198.6 0l0 19.5l-198.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 465.6l191.6 0l0 19.5l-191.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 437.3l181 0l0 19.5l-181 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 409l147.1 0l0 19.5l-147.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 380.7l98.3 0l0 19.5l-98.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 352.4l96.8 0l0 19.5l-96.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 324.1l76.9 0l0 19.5l-76.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 295.8l75.3 0l0 19.5l-75.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 267.5l60 0l0 19.5l-60 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 239.2l60 0l0 19.5l-60 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 210.9l46.1 0l0 19.5l-46.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 182.6l38 0l0 19.5l-38 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="18" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 154.3l35.1 0l0 19.5l-35.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="19" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 126l33.7 0l0 19.5l-33.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="20" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 97.7l28.6 0l0 19.5l-28.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="21" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
-<path d="M155.9 69.4l18.2 0l0 19.5l-18.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="22" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<svg width="900" height="824" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 824">
+<rect width="900" height="824" x="0" y="0" fill="#ffffff"></rect>
+<path d="M156.5 65L156.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M249.5 65L249.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M343.5 65L343.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M436.5 65L436.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M529.5 65L529.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M623.5 65L623.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M716.5 65L716.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M810.5 65L810.5 744" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr0-cls-0"></path>
+<path d="M156.5 744L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr0-cls-0"></path>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 729.8542)" fill="#111">    klona/json</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 701.5625)" fill="#111">    jsondiffpatch.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 673.2708)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 644.9792)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 616.6875)" fill="#111">    fastest-json-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 588.3958)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 560.1042)" fill="#111">    rfdc(circles)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 531.8125)" fill="#111">    nanoclone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 503.5208)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 475.2292)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 446.9375)" fill="#111">    clone-deep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 418.6458)" fill="#111">    JSON.stringify/parse</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 390.3542)" fill="#111">    plain-object-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 362.0625)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 333.7708)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 305.4792)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.1875)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 248.8958)" fill="#111">    copy-anything</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 220.6042)" fill="#111">    just-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.3125)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.0208)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.7292)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.4375)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1458)" fill="#111">    ramda.clone</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 752)" fill="#111">0</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(249.36 752)" fill="#111">50.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(342.8 752)" fill="#111">100.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(436.24 752)" fill="#111">150.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(529.68 752)" fill="#111">200.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(623.12 752)" fill="#111">250.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(716.56 752)" fill="#111">300.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 752)" fill="#111">350.0k</text>
+<path d="M155.9 720.1l582.1 0l0 19.5l-582.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 691.8l570.5 0l0 19.5l-570.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 663.5l521.8 0l0 19.5l-521.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 635.2l462.2 0l0 19.5l-462.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 606.9l417.1 0l0 19.5l-417.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 578.6l282.8 0l0 19.5l-282.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 550.3l262.3 0l0 19.5l-262.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 522.1l251.7 0l0 19.5l-251.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 493.8l193.9 0l0 19.5l-193.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 465.5l186.6 0l0 19.5l-186.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 437.2l173.9 0l0 19.5l-173.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 408.9l133.7 0l0 19.5l-133.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 380.6l100 0l0 19.5l-100 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 352.3l99 0l0 19.5l-99 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 324l76 0l0 19.5l-76 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 295.7l75.8 0l0 19.5l-75.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 267.4l57.1 0l0 19.5l-57.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 239.1l55.6 0l0 19.5l-55.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 210.8l45.5 0l0 19.5l-45.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="18" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 182.6l38.4 0l0 19.5l-38.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="19" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 154.3l34.7 0l0 19.5l-34.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="20" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 126l32.9 0l0 19.5l-32.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="21" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 97.7l29.1 0l0 19.5l-29.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="22" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
+<path d="M155.9 69.4l18.2 0l0 19.5l-18.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="23" ecmeta_ssr_type="chart" class="zr0-cls-1"></path>
 <path d="M-86.6 -5l173.3 0l0 28l-173.3 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr0-cls-0"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">json • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/map-set-large.svg
+++ b/assets/node/map-set-large.svg
@@ -14,8 +14,8 @@
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 335.4333)" fill="#111">    rfdc</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.9667)" fill="#111">    rfdc(circles)</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 278.5)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 250.0333)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.5667)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 250.0333)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.5667)" fill="#111">    structuredClone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 193.1)" fill="#111">    clone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.6333)" fill="#111">    deepcopy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 136.1667)" fill="#111">    clone(circular)</text>
@@ -26,21 +26,21 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(482.96 500)" fill="#111">20.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(646.48 500)" fill="#111">30.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 500)" fill="#111">40.0k</text>
-<path d="M155.9 467.9l621.7 0l0 19.6l-621.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 439.5l611.6 0l0 19.6l-611.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 411l416.3 0l0 19.6l-416.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 382.5l410.9 0l0 19.6l-410.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 354.1l400.2 0l0 19.6l-400.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 325.6l339 0l0 19.6l-339 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 297.1l329.6 0l0 19.6l-329.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 268.7l247.6 0l0 19.6l-247.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 240.2l221.7 0l0 19.6l-221.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 211.7l211.5 0l0 19.6l-211.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 183.3l160.3 0l0 19.6l-160.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 154.8l147 0l0 19.6l-147 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 126.3l127.7 0l0 19.6l-127.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 97.9l93.5 0l0 19.6l-93.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
-<path d="M155.9 69.4l68.1 0l0 19.6l-68.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 467.9l616 0l0 19.6l-616 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 439.5l601.3 0l0 19.6l-601.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 411l402.3 0l0 19.6l-402.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 382.5l396.9 0l0 19.6l-396.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 354.1l393.4 0l0 19.6l-393.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 325.6l325.1 0l0 19.6l-325.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 297.1l316.8 0l0 19.6l-316.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 268.7l242.1 0l0 19.6l-242.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 240.2l207.5 0l0 19.6l-207.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 211.7l205.5 0l0 19.6l-205.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 183.3l158.5 0l0 19.6l-158.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 154.8l136.8 0l0 19.6l-136.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 126.3l126.8 0l0 19.6l-126.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 97.9l92.4 0l0 19.6l-92.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
+<path d="M155.9 69.4l66.9 0l0 19.6l-66.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr17-cls-35"></path>
 <path d="M-101.8 -5l203.5 0l0 28l-203.5 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr17-cls-34"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">map-set • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/map-set-small.svg
+++ b/assets/node/map-set-small.svg
@@ -9,17 +9,17 @@
 <path d="M156.5 492L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr16-cls-32"></path>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 477.7667)" fill="#111">    nanoclone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 449.3)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 420.8333)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 392.3667)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 420.8333)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 392.3667)" fill="#111">    fast-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.9)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 335.4333)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 335.4333)" fill="#111">    nano-copy</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.9667)" fill="#111">    rfdc(circles)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 278.5)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 250.0333)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.5667)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 278.5)" fill="#111">    rfdc</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 250.0333)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.5667)" fill="#111">    structuredClone</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 193.1)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.6333)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 136.1667)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.6333)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 136.1667)" fill="#111">    clone(circular)</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.7)" fill="#111">    lodash.cloneDeep</text>
 <text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.2333)" fill="#111">    core-js/structured-clone</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 500)" fill="#111">0</text>
@@ -28,21 +28,21 @@
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 500)" fill="#111">300.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 500)" fill="#111">400.0k</text>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 500)" fill="#111">500.0k</text>
-<path d="M155.9 467.9l556.2 0l0 19.6l-556.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 439.5l546.1 0l0 19.6l-546.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 411l358.4 0l0 19.6l-358.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 382.5l357 0l0 19.6l-357 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 354.1l293.8 0l0 19.6l-293.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 325.6l201.2 0l0 19.6l-201.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 297.1l199.2 0l0 19.6l-199.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 268.7l196.9 0l0 19.6l-196.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 240.2l161 0l0 19.6l-161 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 211.7l156.1 0l0 19.6l-156.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 183.3l131.6 0l0 19.6l-131.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 154.8l118 0l0 19.6l-118 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 126.3l117.2 0l0 19.6l-117.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 97.9l96.1 0l0 19.6l-96.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
-<path d="M155.9 69.4l53.2 0l0 19.6l-53.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 467.9l541.8 0l0 19.6l-541.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 439.5l534.8 0l0 19.6l-534.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 411l359.7 0l0 19.6l-359.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 382.5l345 0l0 19.6l-345 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 354.1l291.4 0l0 19.6l-291.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 325.6l207.5 0l0 19.6l-207.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 297.1l202 0l0 19.6l-202 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 268.7l201 0l0 19.6l-201 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 240.2l155.2 0l0 19.6l-155.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 211.7l153.4 0l0 19.6l-153.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 183.3l133.4 0l0 19.6l-133.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 154.8l111.7 0l0 19.6l-111.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 126.3l110 0l0 19.6l-110 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 97.9l87.6 0l0 19.6l-87.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
+<path d="M155.9 69.4l49.9 0l0 19.6l-49.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr16-cls-33"></path>
 <path d="M-102.7 -5l205.3 0l0 28l-205.3 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr16-cls-32"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">map-set • small (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/regexp-large.svg
+++ b/assets/node/regexp-large.svg
@@ -1,52 +1,54 @@
-<svg width="900" height="628" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 628">
-<rect width="900" height="628" x="0" y="0" fill="#ffffff"></rect>
-<path d="M156.5 65L156.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M286.5 65L286.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M417.5 65L417.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M548.5 65L548.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M679.5 65L679.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M810.5 65L810.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
-<path d="M156.5 548L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr5-cls-10"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.7941)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 505.3824)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.9706)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 448.5588)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 420.1471)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.7353)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.3235)" fill="#111">    deepcopy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.9118)" fill="#111">    klona/lite</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.5)" fill="#111">    core-js/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 278.0882)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.6765)" fill="#111">    rfdc(with RegExp)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.2647)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.8529)" fill="#111">    ramda.clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.4412)" fill="#111">    lodash.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 136.0294)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.6176)" fill="#111">    clone-deep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.2059)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 556)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 556)" fill="#111">5.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 556)" fill="#111">10.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 556)" fill="#111">15.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 556)" fill="#111">20.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 556)" fill="#111">25.0k</text>
-<path d="M155.9 524l618.1 0l0 19.6l-618.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 495.6l490.1 0l0 19.6l-490.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 467.2l460.9 0l0 19.6l-460.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 438.8l403.7 0l0 19.6l-403.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 410.3l292 0l0 19.6l-292 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 381.9l287.4 0l0 19.6l-287.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 353.5l173.9 0l0 19.6l-173.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 325.1l166.9 0l0 19.6l-166.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 296.7l166 0l0 19.6l-166 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 268.3l151.9 0l0 19.6l-151.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 239.9l124.5 0l0 19.6l-124.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 211.5l122.3 0l0 19.6l-122.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 183.1l111.6 0l0 19.6l-111.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 154.6l95.1 0l0 19.6l-95.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 126.2l76.8 0l0 19.6l-76.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 97.8l56.3 0l0 19.6l-56.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
-<path d="M155.9 69.4l21.9 0l0 19.6l-21.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<svg width="900" height="656" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 656">
+<rect width="900" height="656" x="0" y="0" fill="#ffffff"></rect>
+<path d="M156.5 65L156.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M286.5 65L286.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M417.5 65L417.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M548.5 65L548.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M679.5 65L679.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M810.5 65L810.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr5-cls-10"></path>
+<path d="M156.5 576L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr5-cls-10"></path>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 561.8056)" fill="#111">    nanoclone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.4167)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 505.0278)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.6389)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 448.25)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 419.8611)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.4722)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.0833)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.6944)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.3056)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.9167)" fill="#111">    rfdc(with RegExp)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.5278)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.1389)" fill="#111">    ramda.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.75)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.3611)" fill="#111">    just-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.9722)" fill="#111">    clone-deep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.5833)" fill="#111">    jsondiffpatch.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1944)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 584)" fill="#111">0</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 584)" fill="#111">5.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 584)" fill="#111">10.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 584)" fill="#111">15.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 584)" fill="#111">20.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 584)" fill="#111">25.0k</text>
+<path d="M155.9 552l602.7 0l0 19.6l-602.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 523.6l491.2 0l0 19.6l-491.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 495.2l444.7 0l0 19.6l-444.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 466.8l401.4 0l0 19.6l-401.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 438.5l292.7 0l0 19.6l-292.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 410.1l280.5 0l0 19.6l-280.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 381.7l170.3 0l0 19.6l-170.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 353.3l156.3 0l0 19.6l-156.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 324.9l153.4 0l0 19.6l-153.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 296.5l153 0l0 19.6l-153 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 268.1l127.6 0l0 19.6l-127.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 239.7l119.4 0l0 19.6l-119.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 211.3l106.8 0l0 19.6l-106.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 183l92.1 0l0 19.6l-92.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 154.6l76.9 0l0 19.6l-76.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 126.2l52.7 0l0 19.6l-52.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 97.8l41 0l0 19.6l-41 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
+<path d="M155.9 69.4l21 0l0 19.6l-21 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr5-cls-11"></path>
 <path d="M-96.8 -5l193.6 0l0 28l-193.6 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr5-cls-10"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">regexp • large (ops/s)</text>
 <style ><![CDATA[

--- a/assets/node/regexp-small.svg
+++ b/assets/node/regexp-small.svg
@@ -1,52 +1,54 @@
-<svg width="900" height="628" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 628">
-<rect width="900" height="628" x="0" y="0" fill="#ffffff"></rect>
-<path d="M156.5 65L156.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
-<path d="M286.5 65L286.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
-<path d="M417.5 65L417.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
-<path d="M548.5 65L548.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
-<path d="M679.5 65L679.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
-<path d="M810.5 65L810.5 548" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
-<path d="M156.5 548L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr4-cls-8"></path>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.7941)" fill="#111">    klona/lite</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 505.3824)" fill="#111">    klona</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.9706)" fill="#111">    rfdc(with RegExp)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 448.5588)" fill="#111">    nanoclone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 420.1471)" fill="#111">    nano-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.7353)" fill="#111">    fast-copy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.3235)" fill="#111">    es-toolkit.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.9118)" fill="#111">    clone-deep</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.5)" fill="#111">    just-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 278.0882)" fill="#111">    structuredClone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.6765)" fill="#111">    @ungap/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.2647)" fill="#111">    deepcopy</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.8529)" fill="#111">    clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.4412)" fill="#111">    core-js/structured-clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 136.0294)" fill="#111">    clone(circular)</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.6176)" fill="#111">    ramda.clone</text>
-<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.2059)" fill="#111">    lodash.cloneDeep</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 556)" fill="#111">0</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 556)" fill="#111">100.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 556)" fill="#111">200.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 556)" fill="#111">300.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 556)" fill="#111">400.0k</text>
-<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 556)" fill="#111">500.0k</text>
-<path d="M155.9 524l556 0l0 19.6l-556 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 495.6l519 0l0 19.6l-519 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 467.2l440 0l0 19.6l-440 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 438.8l316.2 0l0 19.6l-316.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 410.3l237 0l0 19.6l-237 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 381.9l212.3 0l0 19.6l-212.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 353.5l197.6 0l0 19.6l-197.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 325.1l181.7 0l0 19.6l-181.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 296.7l142.2 0l0 19.6l-142.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 268.3l127.8 0l0 19.6l-127.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 239.9l127.5 0l0 19.6l-127.5 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 211.5l79.3 0l0 19.6l-79.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 183.1l74.4 0l0 19.6l-74.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 154.6l68.4 0l0 19.6l-68.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 126.2l63.4 0l0 19.6l-63.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 97.8l54.8 0l0 19.6l-54.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
-<path d="M155.9 69.4l54.3 0l0 19.6l-54.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<svg width="900" height="656" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" viewBox="0 0 900 656">
+<rect width="900" height="656" x="0" y="0" fill="#ffffff"></rect>
+<path d="M156.5 65L156.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
+<path d="M286.5 65L286.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
+<path d="M417.5 65L417.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
+<path d="M548.5 65L548.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
+<path d="M679.5 65L679.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
+<path d="M810.5 65L810.5 576" fill="none" pointer-events="visible" stroke="#dbdee4" class="zr4-cls-8"></path>
+<path d="M156.5 576L156.5 65" fill="none" pointer-events="visible" stroke="#999" stroke-linecap="round" class="zr4-cls-8"></path>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 561.8056)" fill="#111">    klona/lite</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 533.4167)" fill="#111">    klona</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 505.0278)" fill="#111">    rfdc(with RegExp)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 476.6389)" fill="#111">    nanoclone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 448.25)" fill="#111">    nano-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 419.8611)" fill="#111">    fast-copy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 391.4722)" fill="#111">    es-toolkit.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 363.0833)" fill="#111">    clone-deep</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 334.6944)" fill="#111">    jsondiffpatch.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 306.3056)" fill="#111">    just-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 277.9167)" fill="#111">    @ungap/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 249.5278)" fill="#111">    structuredClone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 221.1389)" fill="#111">    deepcopy</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 192.75)" fill="#111">    clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 164.3611)" fill="#111">    core-js/structured-clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 135.9722)" fill="#111">    clone(circular)</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 107.5833)" fill="#111">    ramda.clone</text>
+<text dominant-baseline="central" text-anchor="end" style="font-size:12px;font-family:Microsoft YaHei;" xml:space="preserve" transform="translate(151.92 79.1944)" fill="#111">    lodash.cloneDeep</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(155.92 584)" fill="#111">0</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(286.736 584)" fill="#111">100.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(417.552 584)" fill="#111">200.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(548.368 584)" fill="#111">300.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(679.184 584)" fill="#111">400.0k</text>
+<text dominant-baseline="central" text-anchor="middle" style="font-size:12px;font-family:Microsoft YaHei;" y="6" transform="translate(810 584)" fill="#111">500.0k</text>
+<path d="M155.9 552l539.8 0l0 19.6l-539.8 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="0" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 523.6l508.7 0l0 19.6l-508.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="1" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 495.2l419.3 0l0 19.6l-419.3 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="2" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 466.8l308.4 0l0 19.6l-308.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="3" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 438.5l235.7 0l0 19.6l-235.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="4" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 410.1l214 0l0 19.6l-214 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="5" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 381.7l188.7 0l0 19.6l-188.7 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="6" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 353.3l181.9 0l0 19.6l-181.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="7" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 324.9l139.9 0l0 19.6l-139.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="8" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 296.5l132.1 0l0 19.6l-132.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="9" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 268.1l125 0l0 19.6l-125 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="10" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 239.7l123.2 0l0 19.6l-123.2 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="11" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 211.3l77.9 0l0 19.6l-77.9 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="12" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 183l71.1 0l0 19.6l-71.1 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="13" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 154.6l67.6 0l0 19.6l-67.6 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="14" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 126.2l62 0l0 19.6l-62 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="15" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 97.8l53 0l0 19.6l-53 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="16" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
+<path d="M155.9 69.4l52.4 0l0 19.6l-52.4 0Z" fill="#4F46E5" ecmeta_series_index="0" ecmeta_data_index="17" ecmeta_ssr_type="chart" class="zr4-cls-9"></path>
 <path d="M-97.7 -5l195.4 0l0 28l-195.4 0Z" transform="translate(450 20)" fill="rgb(0,0,0)" fill-opacity="0" stroke="#3c3c41" stroke-width="0" class="zr4-cls-8"></path>
 <text dominant-baseline="central" text-anchor="middle" style="font-size:18px;font-family:Microsoft YaHei;font-weight:bold;" xml:space="preserve" y="9" transform="translate(450 20)" fill="#3c3c41">regexp • small (ops/s)</text>
 <style ><![CDATA[

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "es-toolkit": "^1.39.10",
     "fast-copy": "^3.0.2",
     "fastest-json-copy": "^1.0.1",
+    "jsondiffpatch": "^0.7.3",
     "just-clone": "^6.2.0",
     "klona": "^2.0.6",
     "lodash": "^4.17.21",

--- a/src/custom-class/index.spec.ts
+++ b/src/custom-class/index.spec.ts
@@ -16,10 +16,11 @@ const failCases = buildTestCases([
   CloneType.PlainObjectClone,
   CloneType.JSON,
   CloneType.Rfdc,
-  CloneType.RfdcCircles, 
+  CloneType.RfdcCircles,
   CloneType.StructuredClone,
   CloneType.StructuredClonePolyfill,
   CloneType.StructuredCloneCoreJs,
+  CloneType.JsonDiffPatchClone,
 ]);
 
 function isCustomClass(obj: any): obj is CustomClass {

--- a/src/data-structures/array-buffer/index.spec.ts
+++ b/src/data-structures/array-buffer/index.spec.ts
@@ -20,6 +20,7 @@ const failCases = buildTestCases([
   CloneType.Rfdc,
   CloneType.RfdcCircles,
   CloneType.JSON,
+  CloneType.JsonDiffPatchClone,
 ]);
 
 function isTypedArray(obj: any): boolean {

--- a/src/data-structures/buffer/index.spec.ts
+++ b/src/data-structures/buffer/index.spec.ts
@@ -21,6 +21,7 @@ const failCases = buildTestCases([
   CloneType.StructuredClone,
   CloneType.StructuredClonePolyfill,
   CloneType.StructuredCloneCoreJs,
+  CloneType.JsonDiffPatchClone,
 ]);
 
 function isBuffer(obj: any): boolean {

--- a/src/data-structures/map-set/index.spec.ts
+++ b/src/data-structures/map-set/index.spec.ts
@@ -15,6 +15,7 @@ const failCases = buildTestCases([
   CloneType.FastestJsonCopy,
   CloneType.PlainObjectClone,
   CloneType.JSON,
+  CloneType.JsonDiffPatchClone,
 ]);
 
 function isMap(obj: any): boolean {

--- a/src/date/fixtures.ts
+++ b/src/date/fixtures.ts
@@ -104,4 +104,5 @@ export const successCloneType = [
   CloneType.StructuredClone,
   CloneType.StructuredClonePolyfill,
   CloneType.StructuredCloneCoreJs,
+  CloneType.JsonDiffPatchClone,
 ];

--- a/src/json-circular/index.spec.ts
+++ b/src/json-circular/index.spec.ts
@@ -17,6 +17,7 @@ const failCases = buildTestCases([
   CloneType.KlonaJson,
   CloneType.KlonaLite,
   CloneType.PlainObjectClone,
+  CloneType.JsonDiffPatchClone,
 ]);
 
 function assertCircularStructure(cloned: any) {

--- a/src/json/fixtures.ts
+++ b/src/json/fixtures.ts
@@ -61,4 +61,5 @@ export const successCloneType = [
   CloneType.StructuredClonePolyfill,
   CloneType.StructuredCloneCoreJs,
   CloneType.JSON,
+  CloneType.JsonDiffPatchClone,
 ];

--- a/src/regexp/fixtures.ts
+++ b/src/regexp/fixtures.ts
@@ -66,4 +66,5 @@ export const successCloneType = [
   CloneType.StructuredClonePolyfill,
   CloneType.StructuredCloneCoreJs,
   CloneType.StructuredClone,
+  CloneType.JsonDiffPatchClone,
 ];

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -16,6 +16,7 @@ import * as R from "ramda";
 import rfdcFactory from "rfdc";
 import structuredClonePolyfill from "@ungap/structured-clone";
 import structuredCloneCoreJs from "core-js-pure/actual/structured-clone";
+import { clone as jsondiffpatchClone } from "jsondiffpatch";
 const _ = require('lodash');
 
 export class CustomClass {
@@ -87,6 +88,7 @@ export enum CloneType {
   StructuredClonePolyfill = "@ungap/structured-clone",
   StructuredCloneCoreJs = "core-js/structured-clone",
   JSON = "JSON.stringify/parse",
+  JsonDiffPatchClone = "jsondiffpatch.clone"
 }
 
 const rfdc = rfdcFactory();
@@ -140,4 +142,5 @@ export const CloneFn: Record<CloneType, (v: any) => any> = {
   [CloneType.StructuredClonePolyfill]: structuredClonePolyfill,
   [CloneType.StructuredCloneCoreJs]: structuredCloneCoreJs,
   [CloneType.JSON]: (v) => JSON.parse(JSON.stringify(v)),
+  [CloneType.JsonDiffPatchClone]: jsondiffpatchClone,
 } as const;


### PR DESCRIPTION
I noticed the issue of `fastest-json-copy` https://github.com/streamich/fastest-json-copy/issues/3, where a library `jsondiffpatch` is being mentioned. It provides a `clone` method and appears to be faster than `fastest-json-copy`. So I added `jsondiffpatch` to the benchmark suite.

I have enabled `Allow edits by maintainers`, feel free to update the benchmark result in my branch before merging the PR.

Also, I would appreciate it if you could tag `hacktoberfest-accepted` on the PR.